### PR TITLE
fix spelling error "platfrom" in update failed dialog

### DIFF
--- a/client/gui/mainwindow.cpp
+++ b/client/gui/mainwindow.cpp
@@ -2275,7 +2275,7 @@ void MainWindow::showUserWarning(ProtoTypes::UserWarningType userWarningType)
         {
             alreadyShownWarnings_.insert(userWarningType);
             titleText = tr("Check for update failed");
-            descText = tr("Windscribe could not check for update due to an invalid platfrom config. You may want to try manually updating your installation.");
+            descText = tr("Windscribe could not check for update due to an invalid platform config. You may want to try manually updating your installation.");
         }
     }
 


### PR DESCRIPTION
This has been bugging me since I started using the 2.0 client. I did not check other files for similar errors.