### PR TITLE
Fix systemd-resolved syntax for flushing caches

### DIFF
--- a/installer/linux/debian_package/etc/windscribe/update-systemd-resolved
+++ b/installer/linux/debian_package/etc/windscribe/update-systemd-resolved
@@ -440,7 +440,7 @@ main() {
 
     "$script_type" "$link" "$if_index" "$dev" "$@" || return 1
     # Flush the DNS cache
-    systemd-resolve --flush-caches
+    resolvectl flush-caches
   fi
 }
 


### PR DESCRIPTION
This should fix a failure to finalise a connection visually noticeable as indefinitely spinning highlight of Windsribe's "power" button.

The relevant journal message is:
```
helper[4738]: /etc/windscribe/update-systemd-resolved: line 443: systemd-resolve: command not found
```