### PR TITLE
Added StartupWMClass to Desktop Entry

### DIFF
--- a/installer/linux/common/usr/share/applications/windscribe.desktop
+++ b/installer/linux/common/usr/share/applications/windscribe.desktop
@@ -5,3 +5,4 @@ Exec=/opt/windscribe/Windscribe %F
 Name=Windscribe
 Icon=windscribe
 Categories=Network
+StartupWMClass=Windscribe


### PR DESCRIPTION
Linux specific. Very small fix.

StartupWMClass helps DEs identify what windows go with what applications. Without it, it seems that many docks/task managers/etc do not group the launch shortcut/desktop entry and the actual window of the application together. This causes issues if the application is pinned. ["If specified, it is known that the application will map at least one window with the given string as its WM class or WM name hint."](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)

I do not believe there are any side effects to adding this.