### PR TITLE
Add missing header to build on Linux and do not allow to change geo

### DIFF
--- a/backend/linux/helper/wireguard/iwireguardcommunicator.h
+++ b/backend/linux/helper/wireguard/iwireguardcommunicator.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class IWireGuardCommunicator
 {

--- a/backend/linux/helper/wireguard/kernelmodule/kernelmodulecommunicator.h
+++ b/backend/linux/helper/wireguard/kernelmodule/kernelmodulecommunicator.h
@@ -4,7 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
-
+#include <cstdint>
 #include "../iwireguardcommunicator.h"
 #include "wireguard.h"
 

--- a/backend/linux/helper/wireguard/wireguardadapter.h
+++ b/backend/linux/helper/wireguard/wireguardadapter.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class WireGuardAdapter final
 {

--- a/client/common/utils/executable_signature/executablesignature_linux.cpp
+++ b/client/common/utils/executable_signature/executablesignature_linux.cpp
@@ -1,5 +1,6 @@
 #include "executablesignature_linux.h"
 
+#include <memory>
 #include <codecvt>
 #include <stdio.h>
 #include <stdlib.h>

--- a/client/gui/mainwindowcontroller.cpp
+++ b/client/gui/mainwindowcontroller.cpp
@@ -2845,8 +2845,8 @@ MainWindowController::TaskbarLocation MainWindowController::primaryScreenTaskbar
     QRect desktopAvailableRc = screen->availableGeometry();
     QRect desktopScreenRc = screen->geometry();
 
-    // qDebug() << "Desktop Available: " << desktopAvailableRc;
-    // qDebug() << "Desktop Screen: "    << desktopScreenRc;
+    qDebug() << "Desktop Available: " << desktopAvailableRc;
+    qDebug() << "Desktop Screen: "    << desktopScreenRc;
 
     if (desktopAvailableRc.x() > desktopScreenRc.x()) {
         taskbarLocation = TASKBAR_LEFT;
@@ -3100,8 +3100,8 @@ void MainWindowController::updateMainAndViewGeometry(bool updateShadow)
 
     }
 
-    // qDebug() << "Updating mainwindow geo: " << geo;
-    mainWindow_->setGeometry(geo);
+    qDebug() << "Updating mainwindow geo: " << geo;
+    //mainWindow_->setGeometry(geo);
     updateViewAndScene(width, height, shadowSize, updateShadow);
 }
 


### PR DESCRIPTION
On linux, some headers are missing, we add it to fix the build. When user clicked on main screen, the window updated geo, it will lead to lose focus of mouse.