### PR TITLE
Changed Ubuntu image to meet minimum CMake version for Linux docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.10
 
 COPY ./tools/requirements.txt /r/
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y build-essential cmake git curl patchelf libpam0g-dev software-properties-common libgl1-mesa-dev fakeroot python3-pip zip unzip libnl-genl-3-dev pkg-config libcap-ng-dev wget autoconf libtool libfontconfig1-dev libfreetype6-dev libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev libxi-dev libxrender-dev libxcb1-dev libxcb-cursor-dev libxcb-glx0-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-util-dev libxcb-xinerama0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev golang \
- && python3 -m pip install -r /r/requirements.txt
+ && python3 -m pip install -r /r/requirements.txt --break-system-packages
 
 WORKDIR /w


### PR DESCRIPTION
Ubuntu 22.04 does not have the correct CMake version in the repo, this is now fixed by changing the Ubuntu version to 23.10.