### PR TITLE
Update ws_desktop_pl.ts

### DIFF
--- a/client/gui/translations/ws_desktop_pl.ts
+++ b/client/gui/translations/ws_desktop_pl.ts
@@ -1435,7 +1435,7 @@ Jeśli problem nadal występuje po ponownym uruchomieniu, wyślij dziennik debug
     </message>
     <message>
         <source>Discord</source>
-        <translation>Niezgoda</translation>
+        <translation>Discord</translation>
     </message>
     <message>
         <source>View Debug Log</source>


### PR DESCRIPTION
The brand name "Discord" was seemingly erroneously auto-translated. This has been corrected in this pull request to the correct name.