### PR TITLE
fix markdown typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo contains the complete source code for the Windscribe 2.0 app. This inc
 - Install Python 3 via either the Microsoft Store or from [here](https://www.python.org/downloads/). Minimum tested version is 3.6.8.
 - Install CMake v3.28.x or newer from [here](https://cmake.org/download/). The project will build with older versions of CMake, but you may encounter some warnings.
 - Install Ninja v1.10.2 from [here](https://github.com/ninja-build/ninja/releases)
-- Install vcpkg from [here]((https://vcpkg.io/en/getting-started.html)
+- Install vcpkg from [here](https://vcpkg.io/en/getting-started.html)
     - Create a `VCPKG_ROOT` environment variable referencing the full path to your vcpkg install folder.
     - Go to the vcpkg directory and `git checkout 576379156e82da642f8d1834220876759f13534d`.
     - Do the bootstrap step after the above command.


### PR DESCRIPTION
Hello, good day! Just fixing a minor typo that was breaking the readme ^^

(apparently originated from commit [#92fb8f5](https://github.com/Windscribe/Desktop-App/commit/92fb8f5#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5))