### PR TITLE
changes to make proxy gateway only start while VPN is ON, and quit wh…

### DIFF
--- a/client/engine/engine/engine.cpp
+++ b/client/engine/engine/engine.cpp
@@ -2186,13 +2186,13 @@ void Engine::checkForceDisconnectNode(const QStringList & /*forceDisconnectNodes
 
 void Engine::startProxySharingImpl(PROXY_SHARING_TYPE proxySharingType, uint port)
 {
-    vpnShareController_->startProxySharing(proxySharingType, port);
+    vpnShareController_->activateProxySharing(proxySharingType, port);
     emit proxySharingStateChanged(true, proxySharingType, getProxySharingAddress(), 0);
 }
 
 void Engine::stopProxySharingImpl()
 {
-    vpnShareController_->stopProxySharing();
+    vpnShareController_->deactivateProxySharing();
     emit proxySharingStateChanged(false, PROXY_SHARING_HTTP, "", 0);
 }
 

--- a/client/engine/engine/vpnshare/vpnsharecontroller.h
+++ b/client/engine/engine/vpnshare/vpnsharecontroller.h
@@ -25,6 +25,9 @@ public:
     void startProxySharing(PROXY_SHARING_TYPE proxyType, uint port);
     void stopProxySharing();
 
+    void activateProxySharing(PROXY_SHARING_TYPE proxyType, uint port);
+    void deactivateProxySharing();
+
     bool isWifiSharingSupported();
     void startWifiSharing(const QString &ssid, const QString &password);
     void stopWifiSharing();
@@ -46,6 +49,9 @@ private slots:
 private:
     QRecursiveMutex mutex_;
     IHelper *helper_;
+    bool bProxySharingActivated_;
+    PROXY_SHARING_TYPE ActivatedProxySharingType_;
+    uint port_;
     HttpProxyServer::HttpProxyServer *httpProxyServer_;
     SocksProxyServer::SocksProxyServer *socksProxyServer_;
 #ifdef Q_OS_WIN


### PR DESCRIPTION
This might not be ideal for everyone, but i didn't want the gateway proxy to be proxying unless the VPN was also on, otherwise apps that use the https/socks proxy to be private could unintentionally leak 

this changes it so the proxy gateway runs ONLY when the VPN is also on, and turns it off afterward, causing apps using the proxy to fail when connection isn't secured, ideal for me, but others might want some kind of option to work this way or all the time

only tested with socks but should work for both, works for me, very happy this is open source