### PR TITLE
additional apps list config for split tunneling on linux

### DIFF
--- a/client/common/utils/linuxutils.cpp
+++ b/client/common/utils/linuxutils.cpp
@@ -81,7 +81,7 @@ QMap<QString, QString> enumerateInstalledPrograms()
 
     // On Linux, we are looking for desktop entries. These are located under the applications dir at ~/.local/share, and each dir in $XDG_DATA_DIRS
     QStringList dirs = QString::fromLocal8Bit(qgetenv("XDG_DATA_DIRS")).split(":");
-    dirs.prepend(QDir::homePath() + ".local/share");
+    dirs.prepend(QDir::homePath() + "/.local/share");
 
     for (auto dir : dirs) {
         for (auto filename : QDir(dir + "/applications").entryList(QStringList("*.desktop"), QDir::Files)) {
@@ -123,6 +123,23 @@ QMap<QString, QString> enumerateInstalledPrograms()
                 }
             }
         }
+    }
+
+    qCDebug(LOG_BASIC) << "checking additional apps list";
+    // also open the additional apps list so undetected apps can be added simply
+    QFile f(QString(QDir::homePath() + "/.config/Windscribe/additionalapps.list"));
+    if (f.open(QFile::ReadOnly | QFile::Text))
+    {
+        QTextStream in(&f);
+        QStringList contents = in.readAll().split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);
+        for(auto line: contents)
+        {
+            qCDebug(LOG_BASIC) << "added line for " << line;
+            programs[line] = line;
+        }
+    }
+    else {
+        qCDebug(LOG_BASIC) << "couldn't open additional apps list" << QString(QDir::homePath() + ".config/Windscribe/additionalapps.list");
     }
     return programs;
 }


### PR DESCRIPTION
This adds an additional config file that gets checked on linux, to find apps to be added to the app list for split tunneling:
~/.config/Windscribe/additionalapps.list

the existing code doesn't identify lots of apps you might want to add, even when they have .desktop files for some reason some are still missed, not sure why

rather than figure out why the original code wasn't finding everything i just made this kinda half assed solution of just checking a file for a flat list of file paths to include also. it doesn't bother with icons or anything, just adds the paths and now I can add them to split tunneling and it works for me

not sure if you will want this or not but here's an FYI for you
