### PR TITLE
Translate to Belarusian

### DIFF
--- a/src/client/client-common/utils/languagesutil.cpp
+++ b/src/client/client-common/utils/languagesutil.cpp
@@ -14,7 +14,7 @@ QString LanguagesUtil::convertCodeToNative(const QString &code)
     else if (code == "ar") // Arabic
         return "العربية";
     else if (code == "be") // Belarusian
-        return "беларуская";
+        return "Беларуская";
     else if (code == "cs") // Czech
         return "Čeština";
     else if (code == "de") // German

--- a/src/client/frontend/frontend-common/backend/preferences/preferenceshelper.cpp
+++ b/src/client/frontend/frontend-common/backend/preferences/preferenceshelper.cpp
@@ -5,7 +5,7 @@
 PreferencesHelper::PreferencesHelper(QObject *parent) : QObject(parent),
     isWifiSharingSupported_(true), isDockedToTray_(false), isExternalConfigMode_(false)
 {
-    availableLanguageCodes_ << "ar" << "cs" << "de" << "el" << "en" << "es" << "fa" << "fr" << "hi" << "id" << "it" << "ja" << "ko"
+    availableLanguageCodes_ << "ar" << "be" << "cs" << "de" << "el" << "en" << "es" << "fa" << "fr" << "hi" << "id" << "it" << "ja" << "ko"
         << "pl" << "pt" << "ru" << "sk" << "tr" << "uk" << "vi" << "zh-CN" << "zh-TW";
 }
 

--- a/src/client/frontend/gui/CMakeLists.txt
+++ b/src/client/frontend/gui/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(Qt6 REQUIRED COMPONENTS Widgets Network Svg LinguistTools)
 
 set(WS_TS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/ws_desktop_ar.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/ws_desktop_be.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/ws_desktop_cs.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/ws_desktop_de.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/ws_desktop_el.ts

--- a/src/client/frontend/gui/translations/ws_desktop_be.ts
+++ b/src/client/frontend/gui/translations/ws_desktop_be.ts
@@ -1,0 +1,2907 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="be_BY">
+<context>
+<name>AdvancedParametersDialog</name>
+<message>
+<source>Advanced Parameters</source>
+<translation>Дадатковыя парамэтры</translation>
+</message>
+<message>
+<source>Write your parameters here</source>
+<translation>Увядзіце свае парамэтры тут</translation>
+</message>
+<message>
+<source>Clear</source>
+<translation>Ачысьціць</translation>
+</message>
+<message>
+<source>Ok</source>
+<translation>Добра</translation>
+</message>
+<message>
+<source>Cancel</source>
+<translation>Скасаваць</translation>
+</message>
+</context>
+<context>
+<name>CommonGraphics::EscapeButton</name>
+<message>
+<source>ESC</source>
+<translation>ESC</translation>
+</message>
+</context>
+<context>
+<name>ConnectWindow::ConnectWindowItem</name>
+<message>
+<source>Connection to Windscribe has been terminated. </source>
+<translation>Злучэньне з Windscribe прыпынена. </translation>
+</message>
+<message>
+<source> transferred in </source>
+<translation> перададзена за </translation>
+</message>
+<message>
+<source>Connected for </source>
+<translation>Злучана з </translation>
+</message>
+<message>
+<source> transferred</source>
+<translation> перададзена</translation>
+</message>
+<message>
+<source>Firewall</source>
+<translation>Брандмаўэр</translation>
+</message>
+<message>
+<source>Blocks all connectivity in the event of a sudden disconnect</source>
+<translation>Блакуе ўсе злучэньні ў выпадку раптоўнага адлучэньня</translation>
+</message>
+<message>
+<source>Keeping the firewall on while disconnected may break internet connectivity</source>
+<translation>Уключаны брандмаўэр пры адсутнасьці падлучэньня можа парушыць доступ да Інтэрнэту</translation>
+</message>
+<message>
+<source>Favourite IP</source>
+<translation>Абраны IP-адрас</translation>
+</message>
+<message>
+<source>Rotate IP</source>
+<translation>Ратацыя IP-адраса</translation>
+</message>
+<message>
+<source>FIREWALL</source>
+<translation>БРАНДМАЎЭР</translation>
+</message>
+</context>
+<context>
+<name>ConnectWindow::LocationsButton</name>
+<message>
+<source>Locations</source>
+<translation>Месцазнаходжаньні</translation>
+</message>
+</context>
+<context>
+<name>ConnectWindow::LocationsMenu</name>
+<message>
+<source>All</source>
+<translation>Усе</translation>
+</message>
+<message>
+<source>Static IPs</source>
+<translation>Статычныя IP-адрасы</translation>
+</message>
+<message>
+<source>Search</source>
+<translation>Пошук</translation>
+</message>
+<message>
+<source>Custom configs</source>
+<translation>Уласныя канфіґурацыі</translation>
+</message>
+<message>
+<source>Favourites</source>
+<translation>Абранае</translation>
+</message>
+</context>
+<context>
+<name>CustomMenuWidget</name>
+<message>
+<source>Undo</source>
+<translation>Адрабіць</translation>
+</message>
+<message>
+<source>Redo</source>
+<translation>Узнавіць</translation>
+</message>
+<message>
+<source>Cut</source>
+<translation>Выняць</translation>
+</message>
+<message>
+<source>Copy</source>
+<translation>Скапіяваць</translation>
+</message>
+<message>
+<source>Paste</source>
+<translation>Уставіць</translation>
+</message>
+<message>
+<source>Delete</source>
+<translation>Выдаліць</translation>
+</message>
+<message>
+<source>Select All</source>
+<translation>Вылучыць усё</translation>
+</message>
+</context>
+<context>
+<name>EmergencyConnectWindow::EmergencyConnectWindowItem</name>
+<message>
+<source>Emergency Connect</source>
+<translation>Аварыйнае падлучэньне</translation>
+</message>
+<message>
+<source>Emergency connection failure. Try again?</source>
+<translation>Няўдача аварыйнага падлучэньня. Паспрабаваць яшчэ раз?</translation>
+</message>
+<message>
+<source>Can&apos;t access Windscribe.com or login into the app on your restrictive network? Connect to the emergency server that unblocks all of Windscribe.</source>
+<translation>Ня можаце атрымаць доступ да Windscribe.com альбо ўвайці ў праґраму з-за абмежаваньняў сеткі? Падлучайцесь да аварыйнага сэрвэра, які разблакуе ўвесь Windscribe.</translation>
+</message>
+<message>
+<source>Connecting...</source>
+<translation>Падлучэньне...</translation>
+</message>
+<message>
+<source>Disconnecting...</source>
+<translation>Адлучэньне...</translation>
+</message>
+<message>
+<source>Connect</source>
+<translation>Падлучыцца</translation>
+</message>
+<message>
+<source>Disconnect</source>
+<translation>Адлучыцца</translation>
+</message>
+</context>
+<context>
+<name>EmergencyConnectWindow::TextLinkItem</name>
+<message>
+<source>Access for %1 Only</source>
+<translation>Доступ толькі для %1</translation>
+</message>
+</context>
+<context>
+<name>ExternalConfigWindow::ExternalConfigWindowItem</name>
+<message>
+<source>External Config Mode</source>
+<translation>Рэжым зьнешняй канфіґурацыі</translation>
+</message>
+<message>
+<source>Use the Windscribe app without an account to connect to any OpenVPN or WireGuard server.</source>
+<translation>Выкарыстоўвайце праґраму Windscribe без уліковага запісу для падлучэньня да любога сэрвэра OpenVPN альбо WireGuard.</translation>
+</message>
+<message>
+<source>Ok, got it!</source>
+<translation>Добра!</translation>
+</message>
+</context>
+<context>
+<name>FreeTrafficNotificationController</name>
+<message>
+<source>You reached %1% of your free bandwidth allowance</source>
+<translation>Вы дасягнулі %1% ад ліміту бясплатнай прапускной здольнасьці</translation>
+</message>
+</context>
+<context>
+<name>GeneralMessageController</name>
+<message>
+<source>Ok</source>
+<translation>Добра</translation>
+</message>
+<message>
+<source>Yes</source>
+<translation>Так</translation>
+</message>
+<message>
+<source>No</source>
+<translation>Не</translation>
+</message>
+<message>
+<source>Cancel</source>
+<translation>Скасаваць</translation>
+</message>
+</context>
+<context>
+<name>GeneralMessageWindow::GeneralMessageItem</name>
+<message>
+<source>Ignore Warnings</source>
+<translation>Іґнараваць папярэджаньні</translation>
+</message>
+<message>
+<source>Learn More</source>
+<translation>Даведацца больш</translation>
+</message>
+<message>
+<source>Username</source>
+<translation>Імя карыстальніка</translation>
+</message>
+<message>
+<source>Password</source>
+<translation>Пароль</translation>
+</message>
+<message>
+<source>Remember</source>
+<translation>Запомніць</translation>
+</message>
+</context>
+<context>
+<name>GuiLocations::LocationsTab</name>
+<message>
+<source>Choose the directory that contains custom configs you wish to display here</source>
+<translation>Абярыце каталёґ з уласнымі канфіґурацыямі, якія вы хочаце адлюстраваць тут</translation>
+</message>
+<message>
+<source>Choose</source>
+<translation>Абраць</translation>
+</message>
+<message>
+<source>The selected directory contains no custom configs</source>
+<translation>Абраны каталёґ не зьмяшчае ўласных канфіґурацыяў</translation>
+</message>
+<message>
+<source>No locations found</source>
+<translation>Месцазнаходжаньні не знойдзены</translation>
+</message>
+<message>
+<source>Nothing to see here...</source>
+<translation>Тут няма на што глядзець...</translation>
+</message>
+<message>
+<source>You don&apos;t have any Static IPs</source>
+<translation>У вас няма статычных IP-адрасоў</translation>
+</message>
+<message>
+<source>No locations</source>
+<translation>Няма месцазнаходжаньняў</translation>
+</message>
+<message>
+<source>ALL LOCATIONS</source>
+<translation>УСЕ МЕСЦАЗНАХОДЖАНЬНІ</translation>
+</message>
+<message>
+<source>FAVOURITES</source>
+<translation>АБРАНАЕ</translation>
+</message>
+<message>
+<source>STATIC IPs</source>
+<translation>СТАТЫЧНЫЯ IP-адрасы</translation>
+</message>
+<message>
+<source>CUSTOM CONFIGs</source>
+<translation>УЛАСНЫЯ КАНФІҐУРАЦЫІ</translation>
+</message>
+<message>
+<source>SEARCH</source>
+<translation>ПОШУК</translation>
+</message>
+<message>
+<source>Add</source>
+<translation>Дадаць</translation>
+</message>
+</context>
+<context>
+<name>GuiLocations::StaticIPDeviceInfo</name>
+<message>
+<source>Add</source>
+<translation>Дадаць</translation>
+</message>
+</context>
+<context>
+<name>LogViewer::LogViewerWindow</name>
+<message>
+<source>Word Wrap</source>
+<translation>Перанос слоў</translation>
+</message>
+<message>
+<source>Colour highlighting</source>
+<translation>Вылучэньне колерам</translation>
+</message>
+<message>
+<source>Export to file...</source>
+<translation>Экспарт у файл...</translation>
+</message>
+<message>
+<source>Save log</source>
+<translation>Захаваць журнал</translation>
+</message>
+<message>
+<source>Text files (*.txt)</source>
+<translation>Тэкставыя файлы (*.txt)</translation>
+</message>
+<message>
+<source>Export log</source>
+<translation>Экспартаваць журнал</translation>
+</message>
+<message>
+<source>Failed to export log.  Make sure you have the correct permissions.</source>
+<translation>Не атрымалася экспартаваць журнал.  Пераканайцеся, што ў вас ёсьць патрэбныя дазволы.</translation>
+</message>
+</context>
+<context>
+<name>LoginWindow::CaptchaItem</name>
+<message>
+<source>Slide puzzle piece into place</source>
+<translation>Перасуньце элемент галаваломкі на сваё месца</translation>
+</message>
+</context>
+<context>
+<name>LoginWindow::LoggingInWindowItem</name>
+<message>
+<source>Login</source>
+<translation>Увайсьці</translation>
+</message>
+<message>
+<source>Complete Puzzle to continue</source>
+<translation>Каб працягнуць, завяршыце галаваломку</translation>
+</message>
+</context>
+<context>
+<name>LoginWindow::LoginWindowItem</name>
+<message>
+<source>Turn Off Firewall</source>
+<translation>Выключыць брандмаўэр</translation>
+</message>
+<message>
+<source>Login</source>
+<translation>Аўтарызацыя</translation>
+</message>
+<message>
+<source>Emergency Connect is ON</source>
+<translation>Аварыйнае падлучэньне ўключанае</translation>
+</message>
+<message>
+<source>2FA Code</source>
+<translation>Код 2FA</translation>
+</message>
+<message>
+<source>Forgot password?</source>
+<translation>Забыліся пароль?</translation>
+</message>
+<message>
+<source>Standard</source>
+<translation>Стандартная</translation>
+</message>
+<message>
+<source>Hashed</source>
+<translation>Хэшаваная</translation>
+</message>
+<message>
+<source>Username</source>
+<translation>Імя карыстальніка</translation>
+</message>
+<message>
+<source>Enter username</source>
+<translation>Увядзіце імя карыстальніка</translation>
+</message>
+<message>
+<source>Password</source>
+<translation>Пароль</translation>
+</message>
+<message>
+<source>Enter password</source>
+<translation>Увядзіце пароль</translation>
+</message>
+<message>
+<source>Hash</source>
+<translation>Хэш</translation>
+</message>
+<message>
+<source>Account Hash or upload file</source>
+<translation>Хэш уліковага запісу альбо запампаваць файл</translation>
+</message>
+<message>
+<source>Select file for hash</source>
+<translation>Абярыце файл для хэша</translation>
+</message>
+<message>
+<source>All Files (*.*)</source>
+<translation>Усе файлы (*.*)</translation>
+</message>
+<message>
+<source>No Internet Connectivity</source>
+<translation>Адсутнічае падлучэньне да Інтэрнэту</translation>
+</message>
+<message>
+<source>No API Connectivity</source>
+<translation>Адсутнічае падлучэньне да API</translation>
+</message>
+<message>
+<source>Proxy requires authentication</source>
+<translation>Проксі-сэрвэр патрабуе праверкі сапраўднасьці</translation>
+</message>
+<message>
+<source>Invalid API response, check your network</source>
+<translation>Некарэктны адказ API, праверце вашу сетку</translation>
+</message>
+<message>
+<source>Invalid API Endpoint</source>
+<translation>Некарэктная канцавая кропка API</translation>
+</message>
+<message>
+<source>...hmm are you sure this is correct?</source>
+<translation>...хм, вы ўпэўнены, што гэта правільна?</translation>
+</message>
+<message>
+<source>...Sorry, seems like it&apos;s wrong again</source>
+<translation>...Прабачце, здаецца, зноў памылка</translation>
+</message>
+<message>
+<source>...hmm, try resetting your password!</source>
+<translation>...хм, паспрабуйце скінуць пароль!</translation>
+</message>
+<message>
+<source>Rate limited. Please wait before trying to login again.</source>
+<translation>Доступ абмежаваны. Пачакайце, перш чым спрабаваць увайсьці зноў.</translation>
+</message>
+<message>
+<source>Session is expired. Please login again</source>
+<translation>Сесія скончаная. Увайдзіце зноў</translation>
+</message>
+<message>
+<source>Your username should not be an email address. Please try again.</source>
+<translation>Імя карыстальніка не павінна быць адрасам электроннай пошты. Паспрабуйце зноў.</translation>
+</message>
+</context>
+<context>
+<name>LoginWindow::SignupWindowItem</name>
+<message>
+<source>Sign Up</source>
+<translation>Рэґістрацыя</translation>
+</message>
+<message>
+<source>Standard</source>
+<translation>Стандартная</translation>
+</message>
+<message>
+<source>Hashed</source>
+<translation>Хэшаваная</translation>
+</message>
+<message>
+<source>Username</source>
+<translation>Імя карыстальніка</translation>
+</message>
+<message>
+<source>Enter username</source>
+<translation>Увядзіце імя карыстальніка</translation>
+</message>
+<message>
+<source>Password</source>
+<translation>Пароль</translation>
+</message>
+<message>
+<source>Enter password</source>
+<translation>Увядзіце пароль</translation>
+</message>
+<message>
+<source>8 or more characters with at least one uppercase and lowercase(ie. &quot;Hello1234&quot;, &quot;Solyanka&quot;).</source>
+<translation>Не менш за 8 знакаў, у тым ліку як мінімум адна вялікая і адна маленькая літара (напрыклад, &quot;Hello1234&quot;, &quot;Chaladnik&quot;).</translation>
+</message>
+<message>
+<source>Email (Optional)</source>
+<translation>Электронная пошта (неабавязкова)</translation>
+</message>
+<message>
+<source>Enter email</source>
+<translation>Увядзіце электронную пошту</translation>
+</message>
+<message>
+<source>For password recovery, updates &amp; promo only. No spam.</source>
+<translation>Толькі для аднаўленьня пароля, абнаўленьняў і рэклямных акцый. Спаму не будзе.</translation>
+</message>
+<message>
+<source>Voucher Code?</source>
+<translation>Код купона?</translation>
+</message>
+<message>
+<source>Voucher code (optional)</source>
+<translation>Код купона (неабавязкова)</translation>
+</message>
+<message>
+<source>Referred By Someone?</source>
+<translation>Вас нехта запрасіў?</translation>
+</message>
+<message>
+<source>Referring username (optional)</source>
+<translation>Імя карыстальніка запрашальніка (неабавязкова)</translation>
+</message>
+<message>
+<source>Continue</source>
+<translation>Працягнуць</translation>
+</message>
+<message>
+<source>Hash</source>
+<translation>Хэш</translation>
+</message>
+<message>
+<source>Generate or browse file</source>
+<translation>Стварыць альбо абраць файл</translation>
+</message>
+<message>
+<source>No personal info required. Account recovery is impossible.
+If you lose your account hash, it&apos;s gone forever and support cannot help you recover it.</source>
+<translation>Асабістая інфармацыя не патрабуецца. Аднаўленьне ўліковага запісу немагчымае.
+Страціце хэш уліковага запісу — страціце доступ назаўсёды. Служба падтрымкі не зможа дапамагчы.</translation>
+</message>
+<message>
+<source>Select file for hash</source>
+<translation>Абярыце файл для хэша</translation>
+</message>
+<message>
+<source>All Files (*.*)</source>
+<translation>Усе файлы (*.*)</translation>
+</message>
+<message>
+<source>Username must be at least 3 characters</source>
+<translation>Імя карыстальніка павінна мець не менш за 3 знакі</translation>
+</message>
+<message>
+<source>Your username should not be an email address.</source>
+<translation>Імя карыстальніка не павінна быць адрасам электроннай пошты.</translation>
+</message>
+<message>
+<source>Invalid email</source>
+<translation>Няправільная электронная пошта</translation>
+</message>
+<message>
+<source>Invalid hash</source>
+<translation>Няправільны хэш</translation>
+</message>
+</context>
+<context>
+<name>LoginWindow::WelcomeWindowItem</name>
+<message>
+<source>Emergency Connect</source>
+<translation>Аварыйнае падлучэньне</translation>
+</message>
+<message>
+<source>External Config</source>
+<translation>Зьнешняя канфіґурацыя</translation>
+</message>
+<message>
+<source>Preferences</source>
+<translation>Налады</translation>
+</message>
+<message>
+<source>Turn Off Firewall</source>
+<translation>Выключыць брандмаўэр</translation>
+</message>
+<message>
+<source>Login</source>
+<translation>Увайсьці</translation>
+</message>
+<message>
+<source>Get Started</source>
+<translation>Пачаць працу</translation>
+</message>
+</context>
+<context>
+<name>MainWindow</name>
+<message>
+<source>Logging you in...</source>
+<translation>Уваход...</translation>
+</message>
+<message>
+<source>VPN is active</source>
+<translation>VPN дзейны</translation>
+</message>
+<message>
+<source>Rotating your MAC address will result in a disconnect event from the current network. Are you sure?</source>
+<translation>Зьмена MAC-адраса прывядзе да адключэньня ад бягучай сеткі. Вы ўпэўнены?</translation>
+</message>
+<message>
+<source>Cannot detect appropriate packet size while connected. Please disconnect first.</source>
+<translation>Немагчыма вызначыць памер пакета падчас злучэньня. Спачатку адлучыцеся.</translation>
+</message>
+<message>
+<source>No Internet</source>
+<translation>Няма Інтэрнэту</translation>
+</message>
+<message>
+<source>Cannot detect appropriate packet size without internet. Check your connection.</source>
+<translation>Немагчыма вызначыць адпаведны памер пакета без падлучэньня да Інтэрнэту. Праверце падлучэньне.</translation>
+</message>
+<message>
+<source>Select Custom Config Folder</source>
+<translation>Абярыце каталёґ з уласнымі канфіґурацыямі</translation>
+</message>
+<message>
+<source>Cannot select this directory because it is writeable for non-privileged users. Custom configs in this directory may pose a potential security risk. Please authenticate with an admin user to select this directory.</source>
+<translation>Немагчыма абраць гэты каталёґ, бо ў яго могуць запісваць непрывілеяваныя карыстальнікі. Карыстальніцкія канфіґурацыі ў гэтым каталёґу могуць прадстаўляць пагрозу бясьпецы. Каб абраць гэты каталёґ, прайдзіце аўтэнтыфікацыю з дазволамі адміністратара.</translation>
+</message>
+<message>
+<source>Can&apos;t select directory</source>
+<translation>Немагчыма абраць каталёґ</translation>
+</message>
+<message>
+<source>The application is corrupted.  Please reinstall Windscribe.</source>
+<translation>Праґрама пашкоджана. Пераўсталюйце Windscribe.</translation>
+</message>
+<message>
+<source>Validation Error</source>
+<translation>Памылка праверкі спраўнасьці</translation>
+</message>
+<message>
+<source>The selected directory is writeable for non-privileged users. Custom configs in this directory may pose a potential security risk.</source>
+<translation>Абраны каталёґ даступны для запісу непрывілеяванымі карыстальнікамі. Карыстальніцкія канфіґурацыі ў гэтым каталёґу могуць прадстаўляць пагрозу бясьпецы.</translation>
+</message>
+<message>
+<source>Security Risk</source>
+<translation>Рызыка бясьпекі</translation>
+</message>
+<message>
+<source>Enable Service?</source>
+<translation>Уключыць службу?</translation>
+</message>
+<message>
+<source>Enable &quot;Base Filtering Engine&quot; service? This is required for Windscribe to function.</source>
+<translation>Уключыць службу &quot;Base Filtering Engine&quot;? Гэта неабходна для працы Windscribe.</translation>
+</message>
+<message>
+<source>Failed to Enable Service</source>
+<translation>Не ўдалося ўключыць службу</translation>
+</message>
+<message>
+<source>Could not start &apos;Base Filtering Engine&apos; service.  Please enable this service manually in Windows Services.</source>
+<translation>Не ўдалося запусьціць службу &quot;Base Filtering Engine&quot;.  Уключыце гэтую службу ўручную праз дыспэтчар службаў Windows.</translation>
+</message>
+<message>
+<source>Failed to Start</source>
+<translation>Не ўдалося запусьціць</translation>
+</message>
+<message>
+<source>Trying Backup Endpoints %1/%2</source>
+<translation>Спроба рэзэрвовага капіяваньня канцавых кропак %1/%2</translation>
+</message>
+<message>
+<source>SSL Error</source>
+<translation>Памылка SSL</translation>
+</message>
+<message>
+<source>We detected that SSL requests may be intercepted on your network. This could be due to a firewall configured on your computer, or Windscribe being blocked by your network administrator. Ignore SSL errors?</source>
+<translation>Мы выявілі, што ў вашай сетцы могуць перахоплівацца SSL-запыты. Гэта можа быць зьвязана з брандмаўэрам, наладжаным на вашам кампутары, альбо зь блякаваньнем Windscribe адміністратарам вашай сеткі. Ігнараваць памылкі SSL?</translation>
+</message>
+<message>
+<source>Disconnected</source>
+<translation>Адлучана</translation>
+</message>
+<message>
+<source>Connected to </source>
+<translation>Падлучана да </translation>
+</message>
+<message>
+<source>You are now connected to Windscribe (%1).</source>
+<translation>Зараз вы падлучаны да Windscribe (%1).</translation>
+</message>
+<message>
+<source>Connection to Windscribe has been terminated.
+%1 transferred in %2</source>
+<translation>Падлучэньне да Windscribe спынена.
+%1 перададзена за %2</translation>
+</message>
+<message>
+<source>Network Settings Interference</source>
+<translation>Перашкоды ў наладах сеткі</translation>
+</message>
+<message>
+<source>We&apos;ve detected that your network settings may interfere with Windscribe.  Please send us a debug log to troubleshoot.</source>
+<translation>Мы выявілі, што вашы сеткавыя налады могуць перашкаджаць працы Windscribe.  Калі ласка, дашліце нам журнал адладкі, каб мы маглі разабрацца з праблемай.</translation>
+</message>
+<message>
+<source>Send Debug Log</source>
+<translation>Даслаць журнал адладкі</translation>
+</message>
+<message>
+<source>Set “%1” as preferred protocol?</source>
+<translation>Задаць “%1” пераважным пратаколам?</translation>
+</message>
+<message>
+<source>Windscribe will always use this protocol to connect on this network in the future to avoid any interruptions.</source>
+<translation>Windscribe заўсёды будзе выкарыстоўваць гэты пратакол у гэтай сетцы, каб пазьбегнуць перапыненьняў у будучыні.</translation>
+</message>
+<message>
+<source>Set as Preferred</source>
+<translation>Задаць пераважным</translation>
+</message>
+<message>
+<source>Service Error</source>
+<translation>Памылка службы</translation>
+</message>
+<message>
+<source>Windscribe has detected that %1 is using a high amount of CPU due to a potential conflict with the VPN connection. Do you want to disable the Windscribe TCP socket termination feature that may be causing this issue?</source>
+<translation>Windscribe выявіў, што %1 мае высокую загрузку працэсара праз магчымы канфлікт з VPN-злучэньнем. Адключыць функцыю перапыненьня TCP-злучэньняў Windscribe, якая можа быць прычынай гэтай праблемы?</translation>
+</message>
+<message>
+<source>High CPU Usage</source>
+<translation>Высокая загрузка працэсара</translation>
+</message>
+<message>
+<source>MAC Spoofing Failed</source>
+<translation>Падмена MAC-адраса не удалася</translation>
+</message>
+<message>
+<source>Your network adapter does not support MAC spoofing. Try a different adapter.</source>
+<translation>Ваш сеткавы адаптар не падтрымлівае падмену MAC-адраса. Паспрабуйце іншы сеткавы адаптар.</translation>
+</message>
+<message>
+<source>Could not spoof MAC address.  Please try a different network interface or contact support.</source>
+<translation>Не ўдалося падмяніць MAC-адрас.  Паспрабуйце іншы сеткавы інтэрфэйс альбо зьвярніцеся ў службу падтрымкі.</translation>
+</message>
+<message>
+<source>Detection Error</source>
+<translation>Памылка выяўленьня</translation>
+</message>
+<message>
+<source>Cannot detect appropriate packet size due to an error. Please try again.</source>
+<translation>Немагчыма выявіць адпаведны памер пакета з-за памылкі. Паспрабуйце яшчэ раз.</translation>
+</message>
+<message>
+<source>This network hates us</source>
+<translation>Гэта сетка ненавідзіць нас</translation>
+</message>
+<message>
+<source>We couldn’t connect you on this network. Send us your debug log so we can figure out what happened.</source>
+<translation>Нам не ўдалося падлючыцца да вашай сеткі. Дашліце нам журнал адладкі, каб мы маглі высьветліць, што здарылася.</translation>
+</message>
+<message>
+<source>Your debug log has been received. Please contact support if you want assistance with this issue.</source>
+<translation>Журнал адладкі атрыманы. Зьвярніцеся ў службу падтрымкі, калі вам патрэбна дапамога ў вырашэньні гэтай праблемы.</translation>
+</message>
+<message>
+<source>Contact Support</source>
+<translation>Зварот у службу падтрымкі</translation>
+</message>
+<message>
+<source>Auto-Update Failed</source>
+<translation>Аўтаматычнае абнаўленьне не ўдалося</translation>
+</message>
+<message>
+<source>Could not download update.  Please try again or use a different network.</source>
+<translation>Не удалося спампаваць абнаўленьне.  Паўтарыце спробу, альбо падлучыцеся да іншай сеткі.</translation>
+</message>
+<message>
+<source>Could not run updater (Error %1).  Please contact support</source>
+<translation>Не удалося запусьціць абнаўленьне (памылка %1).  Зьвярніцеся ў службу падтрымкі</translation>
+</message>
+<message>
+<source>Lost connection to the backend process.
+Recovering...</source>
+<translation>Страчана злучэньне з сэрвэрам.
+Аднаўляем злучэньне...</translation>
+</message>
+<message>
+<source>Select an application</source>
+<translation>Абярыце праґраму</translation>
+</message>
+<message>
+<source>Read-only file</source>
+<translation>Файл толькі для чытаньня</translation>
+</message>
+<message>
+<source>Your hosts file is read-only. IKEv2 connectivity requires for it to be writable. Fix the issue automatically?</source>
+<translation>Ваш файл hosts даступны толькі для чытаньня. Для падлучэньня IKEv2 патрабуецца магчымасьць запісу ў гэты файл. Выправіць праблему аўтаматычна?</translation>
+</message>
+<message>
+<source>The custom configuration could not be loaded.  Please check that it’s correct or contact support.</source>
+<translation>Не ўдалося загрузіць уласную канфіґурацыю.  Праверце яе карэктнасьць альбо зьвярніцеся ў службу падтрымкі.</translation>
+</message>
+<message>
+<source>WireGuard adapter setup failed. Please wait one minute and try the connection again. If adapter setup fails again, please try restarting your computer.
+
+If the problem persists after a restart, please send a debug log and open a support ticket, then switch to a different connection mode.</source>
+<translation>Памылка ў наладзе адаптара WireGuard. Пачакайце адну хвіліну і паспрабуйце зноў. Калі адаптар не наладзіцца, паспрабуйце перазапусьціць кампутар.
+
+Калі праблема не зьнікне пасьля перазапуска, дашліце журнал адладкі і адкрыйце запыт у службу падтрымкі. Пасьля гэтага пераключыцеся на іншы рэжым падлучэньня.</translation>
+</message>
+<message>
+<source>An unexpected error occurred establishing the VPN connection (Error %1).  If this error persists, try using a different protocol or contact support.</source>
+<translation>Адбылася нечаканая памылка падчас усталяваньня VPN-злучэньня (памылка %1).  Калі памылка не зьнікае, паспрабуйце выкарыстаць іншы пратакол альбо зьвяніцеся ў службу падтрымкі.</translation>
+</message>
+<message>
+<source>Connection Error</source>
+<translation>Памылка злучэньня</translation>
+</message>
+<message>
+<source>Reached Key Limit</source>
+<translation>Дасягнуты ліміт ключоў</translation>
+</message>
+<message>
+<source>You have reached your limit of WireGuard public keys. Do you want to delete your oldest key?</source>
+<translation>Вы дасягнулі ліміту адкрытых ключоў WireGuard. Жадаеце выдаліць найстарэйшы ключ?</translation>
+</message>
+<message>
+<source>Error Starting Service</source>
+<translation>Памылка запуску службы</translation>
+</message>
+<message>
+<source>The split tunneling feature could not be started, and has been disabled in Preferences.</source>
+<translation>Не ўдалося запусьціць функцыю падзелу тунэлю. Яна была аўтаматычна адключана ў наладах.</translation>
+</message>
+<message>
+<source>Unable to start custom DNS service.  Please ensure you don&apos;t have any other local DNS services running, or contact support.</source>
+<translation>Не ўдалося запусьціць уласную службу DNS.  Пераканайцеся, што ў вас не запушчаныя іншыя лякальныя службы DNS, альбо зьвяніцеся ў службу падтрымкі.</translation>
+</message>
+<message>
+<source>JSON Files (*.json)</source>
+<translation>Файлы JSON (*.json)</translation>
+</message>
+<message>
+<source>Unable to import preferences</source>
+<translation>Немагчыма імпартаваць налады</translation>
+</message>
+<message>
+<source>Preferences can only be imported when the app is disconnected. Please disconnect and try again.</source>
+<translation>Налады можна імпартаваць толькі тады, калі праґрама адлучана. Адлучыцесь і паспрабуйце зноў.</translation>
+</message>
+<message>
+<source>The selected file&apos;s format is incorrect.</source>
+<translation>Фармат абранага файлу няправільны.</translation>
+</message>
+<message>
+<source>Export Preferences To</source>
+<translation>Экспартаваць налады ў</translation>
+</message>
+<message>
+<source>Import Preferences From</source>
+<translation>Імпартаваць налады з</translation>
+</message>
+<message>
+<source>Could not open file.</source>
+<translation>Не ўдалося адчыніць файл.</translation>
+</message>
+<message>
+<source>Unable to export preferences</source>
+<translation>Не ўдалося экспартаваць налады</translation>
+</message>
+<message>
+<source>Could not open file for writing.  Check your permissions and try again.</source>
+<translation>Не ўдалося адчыніць файл для запісу.  Праверце правы доступу і паспрабуйце зноў.</translation>
+</message>
+<message>
+<source>Enter Connection Credentials</source>
+<translation>Увядзіце ўліковыя дадзеныя злучэньня</translation>
+</message>
+<message>
+<source>Enter Private Key Password</source>
+<translation>Увядзіце пароль прыватнага ключа</translation>
+</message>
+<message>
+<source>Windscribe could not retrieve server configuration. Please try another protocol.</source>
+<translation>Windscribe не ўдалося атрымаць канфіґурацыю сэрвэра. Паспрабуйце іншы пратакол.</translation>
+</message>
+<message>
+<source>IKEv2 connectivity is not available in MacOS Lockdown Mode. Please disable Lockdown Mode in System Settings or change your connection settings.</source>
+<translation>Падлучэньне IKEv2 недаступнае ў рэжыме Lockdown (MacOS). Адключыце рэжым Lockdown у сістэмных наладах альбо зьмяніце налады злучэньня.</translation>
+</message>
+<message>
+<source>Rotating MAC Address</source>
+<translation>Ратацыя MAC-адраса</translation>
+</message>
+<message>
+<source>Wi-Fi is off</source>
+<translation>Wi-Fi выключаны</translation>
+</message>
+<message>
+<source>Could not start Secure Hotspot</source>
+<translation>Не ўдалося запусьціць бясьпечную кропку доступу</translation>
+</message>
+<message>
+<source>Your network adapter may not support this feature. It has been disabled in preferences.</source>
+<translation>Ваш сеткавы адаптар можа не падтрымліваць гэтую функцыю. Яна была адключаная ў наладах.</translation>
+</message>
+<message>
+<source>...hmm are you sure this is correct?</source>
+<translation>...хм, вы ўпэўнены, што гэта карэктна?</translation>
+</message>
+<message>
+<source>Windscribe has detected that Wi-Fi is currently turned off. To use Secure Hotspot, Wi-Fi must be turned on.</source>
+<translation>Windscribe выявіў, што Wi-Fi выключаны. Каб выкарыстоўваць бясьпечную кропку доступу, Wi-Fi павінен быць уключаны.</translation>
+</message>
+<message>
+<source>Location Services is disabled</source>
+<translation>Служба месцазнаходжаньня выключана</translation>
+</message>
+<message>
+<source>Windscribe requires Location Services to determine your Wi-Fi SSID. If it is not enabled, per-network settings will apply to all Wi-Fi networks. Please enable Location Services and grant the permission to Windscribe in your System Settings.</source>
+<translation>Windscribe патрабуе службу месцазнаходжаньня, каб вызначыць SSID вашай сеткі Wi-Fi. Калі гэтая служба не ўключаная, налады для асобных сетак будуць ужывацца да ўсіх сетак Wi-Fi. Уключыце службу месцазнаходжаньня і надайце Windscribe неабходны дазвол у сістэмных наладах.</translation>
+</message>
+<message>
+<source>Windscribe requires Location Services to determine your Wi-Fi SSID. If it is not enabled, per-network settings will apply to all Wi-Fi networks. Please enable Location Services in your System Settings.</source>
+<translation>Windscribe патрабуе службу месцазнаходжаньня, каб вызначыць SSID вашай сеткі Wi-Fi. Калі гэтая служба не ўключаная, налады для асобных сетак будуць ужывацца да ўсіх сетак Wi-Fi. Уключыце службу месцазнаходжаньня ў сістэмных наладах.</translation>
+</message>
+<message>
+<source>  If you are on a restrictive network, please connect the VPN before trying the download again.</source>
+<translation>  Калі вы карыстаецеся сеткай з абмежаваным доступам, падлучыцеся да VPN, перш чым паўтарыць спробу запампоўкі.</translation>
+</message>
+<message>
+<source>Custom Config Directory Import</source>
+<translation>Імпарт каталяґа ўласных канфіґурацыяў</translation>
+</message>
+<message>
+<source>A custom config directory is being imported.  Windscribe will prompt for your admin password to check for correct permissions.</source>
+<translation>Імпартуецца каталёґ уласных канфіґурацыяў.  Windscribe запытае пароль адміністратара, каб праверыць, ці маюцца патрэбныя дазволы.</translation>
+</message>
+<message>
+<source>Your &quot;Connected DNS&quot; server is set to an OS default DNS server, which would result in a DNS leak.  It has been changed to Auto.</source>
+<translation>Ваш &quot;Падлучаны DNS-сэрвэр&quot; наладжаны на DNS-сэрвэр аперайцыйнай сістэмы па змаўчаньні, што можа прывесьці да ўцечкі DNS.  Ён быў зьменены на &quot;Аўта&quot;.</translation>
+</message>
+<message>
+<source>Invalid DNS Settings</source>
+<translation>Няправільныя налады DNS</translation>
+</message>
+<message>
+<source>System notifications are disabled</source>
+<translation>Сістэмныя паведамленьні выключаныя</translation>
+</message>
+<message>
+<source>You have chosen to show notifications, but system notifications are disabled. Please enable system notifications in your System Settings.</source>
+<translation>Вы ўключылі паказ паведамленьняў, але сістэмныя паведамленьні выключаныя. Уключыце сістэмныя паведамленьні ў наладах сістэмы.</translation>
+</message>
+<message>
+<source>Error Starting Split Tunneling</source>
+<translation>Памылка запуску падзелу тунэля</translation>
+</message>
+<message>
+<source>Export Location Names To</source>
+<translation>Экспартаваць назвы месцазнаходжаньняў у</translation>
+</message>
+<message>
+<source>Unable to export location names</source>
+<translation>Не ўдаецца экспартаваць назвы месцазнаходжаньняў</translation>
+</message>
+<message>
+<source>Import Location Names From</source>
+<translation>Імпартаваць назвы месцазнаходжаньняў з</translation>
+</message>
+<message>
+<source>Unable to import location names</source>
+<translation>Не ўдаецца імпартаваць назвы месцазнаходжаньняў</translation>
+</message>
+<message>
+<source>The split tunneling feature has been disabled because the Windscribe split tunnel extension is not enabled in System Settings.  To use this feature, please enable the extension in System Settings, and turn on the feature again.</source>
+<translation>Функцыя падзелу тунэля была адключана, бо пашырэньне Windscribe для падзелу тунэля не ўключана ў сістэмных наладах.  Каб скарыстацца гэта функцыяй, уключыце пашырэньне ў сістэмных наладах, а затым уключыце функцыю зноў.</translation>
+</message>
+<message>
+<source>Debug Log Sent!</source>
+<translation>Журнал адладкі адасланы!</translation>
+</message>
+<message>
+<source>Could not connect to the Windscribe service.  Windscribe will now exit.  Please contact support.</source>
+<translation>Не ўдалося падлучыцца да службы Windscribe.  Windscribe зараз завершыць працу.  Зьвярніцеся ў службу падтрымкі.</translation>
+</message>
+<message>
+<source>Lost connection to the Windscribe service.  Windscribe will now exit.  Send us a debug log so we can improve this.</source>
+<translation>Страчана злучэньне са службай Windscribe. Windscribe зараз завершыць працу. Дашліце нам журнал адладкі, каб мы маглі палепшыць працу праґрамы.</translation>
+</message>
+<message>
+<source>Local DNS server is not available</source>
+<translation>Лякальны DNS-сэрвэр недасяжны</translation>
+</message>
+<message>
+<source>The local DNS server is not available.  Connected DNS has been set back to Auto.</source>
+<translation>Лякальны DNS-сэрвэр недасяжны.  Падлучаны DNS быў зноў усталяваны ў рэжым &quot;Аўта&quot;.</translation>
+</message>
+<message>
+<source>DNS Server Conflict</source>
+<translation>Канфлікт DNS-сэрвэра</translation>
+</message>
+<message>
+<source>Unable to start custom DNS service - port 53 is already in use.  Would you like to change your Connected DNS to the local server?</source>
+<translation>Не ўдалося запусьціць уласную службу DNS - порт 53 ужо заняты.  Зьмяніць падлучаны DNS на лякальны сэрвэр?</translation>
+</message>
+<message>
+<source>Could not pin IP</source>
+<translation>Не ўдалося замацаваць IP-адрас</translation>
+</message>
+<message>
+<source>We could not set your favourite IP for this location.  Try again later.</source>
+<translation>Не ўдалося ўсталяваць абраны IP-адрас для гэтага месцазнаходжаньня.  Паўтарыце спробу пазьней.</translation>
+</message>
+<message>
+<source>Could not rotate IP</source>
+<translation>Не ўдалося зьмяніць IP-адрас</translation>
+</message>
+<message>
+<source>Try again later or go to our Status page for more info.</source>
+<translation>Паўтарыце спробу пазьней альбо перайдзіце на старонку стану па дадатковую інфармацыю.</translation>
+</message>
+<message>
+<source>Check Location Status</source>
+<translation>Праверце стан месцазнаходжаньня</translation>
+</message>
+<message>
+<source>Back</source>
+<translation>Назад</translation>
+</message>
+<message>
+<source>Manual connection mode failed</source>
+<translation>Памылка рэжыму ручнога злучэньня</translation>
+</message>
+<message>
+<source>We couldn’t connect you on this network. Automatic connection mode recommended for best results. Switch connection mode to Auto?</source>
+<translation>Не ўдалося падлучыцца да гэтай сеткі. Рэкамендуецца аўтаматычны рэжым падлучэньня. Пераключыць рэжым падлучэньня на &quot;Аўта&quot;?</translation>
+</message>
+<message>
+<source>Switch to Auto</source>
+<translation>Пераключыцца на &quot;Аўта&quot;</translation>
+</message>
+<message>
+<source>Creating your account...</source>
+<translation>Стварэньне вашага ўліковага запісу...</translation>
+</message>
+<message>
+<source>Cannot rotate MAC address while connected to VPN. Please disconnect first.</source>
+<translation>Немагчыма зьмяніць MAC-адрас падчас злучэньня. Спачатку адлучыцеся.</translation>
+</message>
+</context>
+<context>
+<name>MainWindowController</name>
+<message>
+<source>Quit Windscribe?</source>
+<translation>Зачыніць Windscribe?</translation>
+</message>
+<message>
+<source>Log Out of Windscribe?</source>
+<translation>Выйсьці з уліковага запісу Windscribe?</translation>
+</message>
+<message>
+<source>Quit</source>
+<translation>Зачыніць</translation>
+</message>
+<message>
+<source>Log Out</source>
+<translation>Выйсьці з уліковага запісу</translation>
+</message>
+<message>
+<source>Cancel</source>
+<translation>Скасаваць</translation>
+</message>
+</context>
+<context>
+<name>NewsFeedWindow::NewsFeedWindowItem</name>
+<message>
+<source>News Feed</source>
+<translation>Стужка навін</translation>
+</message>
+</context>
+<context>
+<name>NotificationsController</name>
+<message>
+<source>WELCOME TO WINDSCRIBE</source>
+<translation>ВІТАЕМ У WINDSCRIBE</translation>
+</message>
+<message>
+<source>&lt;p&gt;You will find announcements and general Windscribe related news here. Perhaps even delicious cake, everyone loves cake!&lt;/p&gt;</source>
+<translation>&lt;p&gt;Тут вы знойдзеце аб&apos;явы і агульныя навіны пра Windscribe. Магчыма, нават смачны торт, бо ўсе любяць торт!&lt;/p&gt;</translation>
+</message>
+</context>
+<context>
+<name>Preferences</name>
+<message>
+<source>Invalid DNS Settings</source>
+<translation>Няспраўныя налады DNS</translation>
+</message>
+<message>
+<source>&apos;Connected DNS&apos; was not configured with a valid Upstream 1 (IP/DNS-over-HTTPS/TLS). DNS was reverted to ROBERT (default).</source>
+<translation>&apos;Падлучаны DNS&apos; не быў наладжаны з карэктным Upstream 1 (IP/DNS-over-HTTPS/TLS). DNS быў зноў усталяваны на ROBERT (па змаўчаньні).</translation>
+</message>
+<message>
+<source>&apos;Connected DNS&apos; was not configured with a valid Upstream 2 (IP/DNS-over-HTTPS/TLS). DNS was reverted to ROBERT (default).</source>
+<translation>&apos;Падлучаны DNS&apos; не быў наладжаны з карэктным Upstream 2 (IP/DNS-over-HTTPS/TLS). DNS быў зноў усталяваны на ROBERT (па змаўчаньні).</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::AboutWindowItem</name>
+<message>
+<source>About</source>
+<translation>Аб праґраме</translation>
+</message>
+<message>
+<source>Status</source>
+<translation>Стан</translation>
+</message>
+<message>
+<source>About Us</source>
+<translation>Пра нас</translation>
+</message>
+<message>
+<source>Privacy Policy</source>
+<translation>Палітыка прыватнасьці</translation>
+</message>
+<message>
+<source>Terms</source>
+<translation>Умовы</translation>
+</message>
+<message>
+<source>Blog</source>
+<translation>Блоґ</translation>
+</message>
+<message>
+<source>Jobs</source>
+<translation>Вакансіі</translation>
+</message>
+<message>
+<source>Software Licenses</source>
+<translation>Ліцензіі на ПЗ</translation>
+</message>
+<message>
+<source>Changelog</source>
+<translation>Сьпіс зьменаў</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::AccountWindowItem</name>
+<message>
+<source>Login to view your account info</source>
+<translation>Увайдзіце, каб пабачыць зьвесткі уліковага запісу</translation>
+</message>
+<message>
+<source>Login</source>
+<translation>Увайсьці</translation>
+</message>
+<message>
+<source>Account</source>
+<translation>Уліковы запіс</translation>
+</message>
+<message>
+<source>Username</source>
+<translation>Імя карыстальніка</translation>
+</message>
+<message>
+<source>Reset Date</source>
+<translation>Тэрмін дзеяньня</translation>
+</message>
+<message>
+<source>Data Left</source>
+<translation>Астатак трафіку</translation>
+</message>
+<message>
+<source>Manage Account</source>
+<translation>Кіраваньне ўліковым запісам</translation>
+</message>
+<message>
+<source>Expiry Date</source>
+<translation>Дата заканчэньня</translation>
+</message>
+<message>
+<source>ACCOUNT INFO</source>
+<translation>ЗЬВЕСТКІ АБ УЛІКОВЫМ ЗАПІСЕ</translation>
+</message>
+<message>
+<source>PLAN INFO</source>
+<translation>ЗЬВЕСТКІ АБ ТАРЫФЕ</translation>
+</message>
+<message>
+<source>UPGRADE &gt;</source>
+<translation>ПАЛЕПШЫЦЬ &gt;</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::AdvancedWindowItem</name>
+<message>
+<source>Advanced Options</source>
+<translation>Пашыраныя налады</translation>
+</message>
+<message>
+<source>Make advanced tweaks to the way the app functions.</source>
+<translation>Унясіце дадатковыя зьмены ў працу праґрамы.</translation>
+</message>
+<message>
+<source>Advanced Parameters</source>
+<translation>Дадатковыя парамэтры</translation>
+</message>
+<message>
+<source>Ignore SSL certificate validation errors.</source>
+<translation>Іґнараваць памылкі праверкі SSL-сэртыфіката.</translation>
+</message>
+<message>
+<source>Ignore SSL Errors</source>
+<translation>Іґнараваць памылкі SSL</translation>
+</message>
+<message>
+<source>Prevents connections from dying (by time-out) by periodically pinging the server.</source>
+<translation>Прадухіляе разрыў злучэньняў з-за сканчэньня часу чаканьня, пэрыядычна правяраючы дасяжнасьць сэрвэра.</translation>
+</message>
+<message>
+<source>Client-side Keepalive</source>
+<translation>Падтрыманьне злучэньня</translation>
+</message>
+<message>
+<source>Windscribe uses this DNS server to resolve addresses outside the VPN.</source>
+<translation>Windscribe выкарыстоўвае гэтый DNS-сэрвэр для вызначэньня адрасоў па-за межамі VPN.</translation>
+</message>
+<message>
+<source>Warning: Using &quot;OS Default&quot; may sometimes cause DNS leaks during reconnects.</source>
+<translation>Папярэджаньне: выкарыстаньне &quot;OS Default&quot; часам можа прывесьці да ўцечак DNS падчас паўторных падлучэньняў.</translation>
+</message>
+<message>
+<source>App Internal DNS</source>
+<translation>Унутраны DNS</translation>
+</message>
+<message>
+<source>Select the DNS system service Windscribe enforces. Experienced users only.</source>
+<translation>Абярыце сістэмную службу DNS, якую будзе прымусова выкарыстоўваць Windscribe. Толькі для дасьведчаных карыстальнікаў.</translation>
+</message>
+<message>
+<source>DNS Manager</source>
+<translation>Кіраваньне DNS</translation>
+</message>
+<message>
+<source>App Preferences</source>
+<translation>Кіраваньне DNS</translation>
+</message>
+<message>
+<source>Export</source>
+<translation>Экспартаваць</translation>
+</message>
+<message>
+<source>Import</source>
+<translation>Імпартаваць</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::AntiCensorshipGroup</name>
+<message>
+<source>Circumvent Censorship</source>
+<translation>Абыход цэнзуры</translation>
+</message>
+<message>
+<source>Configuration</source>
+<translation>Канфіґурацыя</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::AppBackgroundGroup</name>
+<message>
+<source>App Background</source>
+<translation>Фон праґрамы</translation>
+</message>
+<message>
+<source>Aspect Ratio Mode</source>
+<translation>Прапорцыі</translation>
+</message>
+<message>
+<source>When Disconnected</source>
+<translation>Калі адлучана</translation>
+</message>
+<message>
+<source>Flags</source>
+<translation>Сьцягі</translation>
+</message>
+<message>
+<source>Bundled</source>
+<translation>Стандартны</translation>
+</message>
+<message>
+<source>None</source>
+<translation>Няма</translation>
+</message>
+<message>
+<source>Custom</source>
+<translation>Уласны</translation>
+</message>
+<message>
+<source>When Connected</source>
+<translation>Калі падлучана</translation>
+</message>
+<message>
+<source>Select an image</source>
+<translation>Абярыце выяву</translation>
+</message>
+<message>
+<source>Square</source>
+<translation>Квадраты</translation>
+</message>
+<message>
+<source>Palm</source>
+<translation>Пальмы</translation>
+</message>
+<message>
+<source>Drip</source>
+<translation>Кроплі</translation>
+</message>
+<message>
+<source>Snow</source>
+<translation>Сьнег</translation>
+</message>
+<message>
+<source>Ripple</source>
+<translation>Кругі на вадзе</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::ConnectedDnsGroup</name>
+<message>
+<source>Connected DNS</source>
+<translation>Актыўны DNS</translation>
+</message>
+<message>
+<source>Upstream 1</source>
+<translation>DNS-сэрвэр 1</translation>
+</message>
+<message>
+<source>IP/DNS-over-HTTPS/TLS</source>
+<translation>IP/DNS-over-HTTPS/TLS</translation>
+</message>
+<message>
+<source>Upstream 2</source>
+<translation>DNS-сэрвэр 2</translation>
+</message>
+<message>
+<source>Split DNS</source>
+<translation>Падзел DNS</translation>
+</message>
+<message>
+<source>Domains</source>
+<translation>Дамэны</translation>
+</message>
+<message>
+<source>DNS leak detected</source>
+<translation>Выяўлена ўцечка DNS</translation>
+</message>
+<message>
+<source>Using a LAN or local IP address for connected DNS will result in a DNS leak.  We strongly recommend using ROBERT or a public DNS server.</source>
+<translation>Выкарыстаньне лякальнага альбо LAN-адраса для DNS пры падлучэньні прывядзе да ўцечкі DNS. Найстойліва раім выкарыстоўваць ROBERT альбо публічны DNS-сэрвэр.</translation>
+</message>
+<message>
+<source>API Key</source>
+<translation>Ключ API</translation>
+</message>
+<message>
+<source>Failed to reach Control D API.</source>
+<translation>Не ўдалося зьвязацца з Control D API.</translation>
+</message>
+<message>
+<source>Please provide a valid Control D API Key.</source>
+<translation>Падайце дзейсны ключ Control D API.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::ConnectionWindowItem</name>
+<message>
+<source>Allow LAN Traffic</source>
+<translation>Дазволіць LAN-трафік</translation>
+</message>
+<message>
+<source>Terminate Sockets</source>
+<translation>Закрываць сокеты</translation>
+</message>
+<message>
+<source>Connection</source>
+<translation>Злучэньне</translation>
+</message>
+<message>
+<source>Exclusive</source>
+<translation>Выключны</translation>
+</message>
+<message>
+<source>Inclusive</source>
+<translation>Уключны</translation>
+</message>
+<message>
+<source>Off</source>
+<translation>Выкл.</translation>
+</message>
+<message>
+<source>Network Options</source>
+<translation>Налады сеткі</translation>
+</message>
+<message>
+<source>Split Tunneling</source>
+<translation>Падзел тунэлю</translation>
+</message>
+<message>
+<source>Proxy Settings</source>
+<translation>Налады проксі</translation>
+</message>
+<message>
+<source>Connects to last used location when the app launches or joins a network.</source>
+<translation>Аўтаматычна падлучаецца да апошняга выкарыстанага месцазнаходжаньня пры запуску праґрамы альбо падлучэньні да сеткі.</translation>
+</message>
+<message>
+<source>Auto-Connect</source>
+<translation>Аўтападлучэньне</translation>
+</message>
+<message>
+<source>Control the mode of behaviour of the Windscribe firewall.</source>
+<translation>Кіраваньне рэжымам працы брандмаўэра Windscribe.</translation>
+</message>
+<message>
+<source>Connection Mode</source>
+<translation>Рэжым злучэньня</translation>
+</message>
+<message>
+<source>Automatically choose the VPN protocol, or select one manually. NOTE: &quot;Preferred Protocol&quot; will override this setting.</source>
+<translation>Аўтаматычны альбо ручны выбар VPN-пратакола. Заўвага: &quot;Пераважны пратакол&quot; будзе мець прыярытэт над гэтай наладай.</translation>
+</message>
+<message>
+<source>Select the DNS server while connected to Windscribe.</source>
+<translation>Абярыце DNS-сэрвэр падчас злучэньня з Windscribe.</translation>
+</message>
+<message>
+<source>Allow access to local services and printers while connected to Windscribe.</source>
+<translation>Дазволіць доступ да лякальных службаў і друкарак падчас злучэньня з Windscribe.</translation>
+</message>
+<message>
+<source>Spoof your device&apos;s physical address (MAC address).</source>
+<translation>Падмяніць фізычны адрас прылады (MAC-адрас).</translation>
+</message>
+<message>
+<source>Close all active TCP sockets when the VPN tunnel is established.</source>
+<translation>Закрываць усе актыўныя TCP-злучэньні пасля ўсталяваньня VPN-тунэлю.</translation>
+</message>
+<message>
+<source>Configure your TV, gaming console, or other devices that support proxy servers.</source>
+<translation>Наладзьце тэлевізар, гульнявую кансоль альбо іншыя прылады, якія падтрымліваюць проксі-сэрвэры.</translation>
+</message>
+<message>
+<source>Settings Conflict</source>
+<translation>Канфлікт налад</translation>
+</message>
+<message>
+<source>Disabling Allow LAN Traffic will cause your proxy gateway to stop working.  Do you want to disable the proxy?</source>
+<translation>Адключэньне дазволу трафіку лякальнай сеткі прывядзе да спыненьня працы проксі-шлюза.  Адключыць проксі?</translation>
+</message>
+<message>
+<source>LAN traffic is currently blocked by the Windscribe firewall.  Do you want to allow LAN traffic to bypass the firewall in order for this feature to work?</source>
+<translation>Трафік лякальнай сеткі зараз блакуецца брандмаўэрам Windscribe.  Дазволіць трафіку лакальнай сеткі абыходзіць брандмаўэр для працы гэтай функцыі?</translation>
+</message>
+<message>
+<source>Disabling Allow LAN Traffic will cause your secure hotspot to stop working.  Do you want to disable the hotspot?</source>
+<translation>Адключэньне дазволу трафіку лякальнай сеткі прывядзе да спыненьня працы бясьпечнай кропкі доступу.  Адключыць кропку доступу?</translation>
+</message>
+<message>
+<source>MAC spoofing is not supported on your version of MacOS.</source>
+<translation>Падмена MAC-адраса не падтрымліваецца ў гэтай версіі MacOS.</translation>
+</message>
+<message>
+<source>Automatically determine the MTU for your connection, or manually override.  This has no effect on TCP-based protocols.</source>
+<translation>Аўтаматычна вызначайце MTU для падлучэньня альбо задавайце яго ўручную.  Гэта не ўплывае на пратаколы, заснаваныя на TCP.</translation>
+</message>
+<message>
+<source>Caution</source>
+<translation>Увага</translation>
+</message>
+<message>
+<source>In this firewall mode, the Windscribe API will not be available while disconnected, this could have unintended consequences. Use at own risk.</source>
+<translation>У гэтым рэжыме брандмаўэра API Windscribe не будзе даступны, калі VPN не падлучаны, што можа мець непрадбачаныя наступствы. Выкарыстоўвайце на ўласную рызыку.</translation>
+</message>
+<message>
+<source>Clear Wi-Fi History</source>
+<translation>Выдаліць гісторыю Wi-Fi</translation>
+</message>
+<message>
+<source>Are you sure?</source>
+<translation>Вы ўпэўнены?</translation>
+</message>
+<message>
+<source>Are you sure you want to clear all your Wi-Fi history? This will also clear all Wi-Fi passwords except for the one you&apos;re currently connected to. This may also temporarily disable your Wi-Fi.</source>
+<translation>Вы ўпэўнены, што хочаце выдаліць усю гісторыю Wi-Fi? Гэта таксама выдаліць усе паролі Wi-Fi, акрамя пароля сеткі, да якой вы зараз падлучаныя. Гэта таксама можа часова адключыць Wi-Fi.</translation>
+</message>
+<message>
+<source>Remove Wi-Fi SSID and MAC information from your operating system to prevent location history tracking.</source>
+<translation>Выдаліце зьвесткі пра SSID і MAC-адрас Wi-Fi з аперацыйнай сыстэмы, каб прадухіліць адсочваньне гісторыі месцазнаходжаньня.</translation>
+</message>
+<message>
+<source>Connect to the VPN with WireGuard even in a hostile environment.</source>
+<translation>Падлучайцеся да VPN з дапамогай WireGuard нават у варожым сеткавым асяродьдзі.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::DecoyTrafficGroup</name>
+<message>
+<source>Decoy Traffic</source>
+<translation>Імітацыя трафіку</translation>
+</message>
+<message>
+<source>This is an experimental feature that attempts to combat traffic correlation attacks on adversarial networks.When enabled, the app will generate random activity over the tunnel, and upload and download random data at chosen intervals.</source>
+<translation>Гэта экспэрымэнтальная функцыя для супрацьдзеяньня атакам карэляцыі трафіку ў варожых сетках. Пры ўключэньні, праґрама будзе ствараць выпадковую дзейнасьць у тунэлі, а таксама спампоўваць і запампоўваць выпадковыя дадзеныя ў вызначаныя прамежкі часу.</translation>
+</message>
+<message>
+<source>Fake Traffic Volume</source>
+<translation>Аб’ём імітацыі трафіку</translation>
+</message>
+<message>
+<source>Low</source>
+<translation>Малы</translation>
+</message>
+<message>
+<source>Medium</source>
+<translation>Сярэдні</translation>
+</message>
+<message>
+<source>High</source>
+<translation>Вялікі</translation>
+</message>
+<message>
+<source>Estimated Data Usage</source>
+<translation>Прыблізны расход</translation>
+</message>
+<message>
+<source>%1/hour</source>
+<translation>%1/гадзіна</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::DnsDomainsGroup</name>
+<message>
+<source>Domain already exists. Please enter a new domain.</source>
+<translation>Дамэн ужо існуе. Увядзіце іншы дамэн.</translation>
+</message>
+<message>
+<source>Incorrect domain name. Please enter a valid domain.</source>
+<translation>Няправільнае імя дамэна. Увядзіце карэктны дамэн.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::DnsDomainsWindowItem</name>
+<message>
+<source>List of domains</source>
+<translation>Сьпіс дамэнаў</translation>
+</message>
+<message>
+<source>Enter the IP and/or wildcards you wish to use for DNS split feature.</source>
+<translation>Увядзіце IP-адрас і/альбо падстаноўчыя сымбалі для выкарыстаньня ў функцыі падзеленага DNS.</translation>
+</message>
+<message>
+<source>Please log in to modify domains.</source>
+<translation>Увайдзіце, каб зьмяніць дамэны.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::EmailItem</name>
+<message>
+<source>Sent!</source>
+<translation>Адаслана!</translation>
+</message>
+<message>
+<source>Resend</source>
+<translation>Адаслаць зноў</translation>
+</message>
+<message>
+<source>Sending</source>
+<translation>Адсылаецца</translation>
+</message>
+<message>
+<source>Failed</source>
+<translation>Не даслана</translation>
+</message>
+<message>
+<source>Get 10GB/Month of data and gain the ability to reset your password.</source>
+<translation>Атрымайце 10ГБ дадзеных у месяц і магчымасьць скінуць пароль.</translation>
+</message>
+<message>
+<source>Please confirm your email</source>
+<translation>Пацьвердзіце адрас электроннай пошты</translation>
+</message>
+<message>
+<source>Email</source>
+<translation>Эл. пошта</translation>
+</message>
+<message>
+<source>Add Email</source>
+<translation>Дадаць эл. пошту</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::FirewallGroup</name>
+<message>
+<source>Firewall Mode</source>
+<translation>Рэжым брандмаўэра</translation>
+</message>
+<message>
+<source>When?</source>
+<translation>Калі?</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::GeneralWindowItem</name>
+<message>
+<source>General</source>
+<translation>Агульныя</translation>
+</message>
+<message>
+<source>Run Windscribe when your device starts.</source>
+<translation>Запускаць Windscribe пры старце сістэмы.</translation>
+</message>
+<message>
+<source>Launch on Startup</source>
+<translation>Запускаць пры старце</translation>
+</message>
+<message>
+<source>Launch Windscribe in a minimized state.</source>
+<translation>Запускаць Windscribe у згорнутым стане.</translation>
+</message>
+<message>
+<source>Start Minimized</source>
+<translation>Запускаць згорнутым</translation>
+</message>
+<message>
+<source>Windscribe minimizes to system tray and no longer appears in the task bar.</source>
+<translation>Windscribe згортваецца ў сістэмную панэль і больш не адлюстроўваецца на панэлі заданьняў.</translation>
+</message>
+<message>
+<source>Windscribe minimizes to menubar and no longer appears in the dock.</source>
+<translation>Windscribe згортваецца ў верхнюю панэль і больш не адлюстроўваецца ў Dock.</translation>
+</message>
+<message>
+<source>Close to Tray</source>
+<translation>Згортваць у панэль</translation>
+</message>
+<message>
+<source>Don&apos;t show the Windscribe icon in dock.</source>
+<translation>Не адлюстроўваць значак Windscribe у Dock.</translation>
+</message>
+<message>
+<source>Hide from Dock</source>
+<translation>Хаваць з Dock</translation>
+</message>
+<message>
+<source>Pin Windscribe near the system tray or menu bar.</source>
+<translation>Замацуйце Windscribe побач з сістэмнай панельлю альбо верхняй панельлю.</translation>
+</message>
+<message>
+<source>Docked</source>
+<translation>Замацаваны</translation>
+</message>
+<message>
+<source>Display system-level notifications when connection events occur.</source>
+<translation>Паказваць сістэмныя апавяшчэньні пры зьменах стану злучэньня.</translation>
+</message>
+<message>
+<source>Show Notifications</source>
+<translation>Апавяшчэньні</translation>
+</message>
+<message>
+<source>Display a location&apos;s load. Shorter bars mean lesser load (usage).</source>
+<translation>Паказваць нагрузку месцазнаходжаньняў. Карацейшыя слупкі азначаюць меншую нагрузку (выкарыстаньне).</translation>
+</message>
+<message>
+<source>Show Location Load</source>
+<translation>Паказваць нагрузку</translation>
+</message>
+<message>
+<source>Arrange locations alphabetically, geographically, or by latency.</source>
+<translation>Сартаваць месцазнаходжаньні па альфабэту, геаграфіі альбо затрымцы.</translation>
+</message>
+<message>
+<source>Location Order</source>
+<translation>Парадак месцаў</translation>
+</message>
+<message>
+<source>Localize Windscribe to supported languages.</source>
+<translation>Абярыце мову інтэрфэйсу Windscribe.</translation>
+</message>
+<message>
+<source>Language</source>
+<translation>Мова</translation>
+</message>
+<message>
+<source>Choose to receive stable, beta, or experimental builds.</source>
+<translation>Абярыце канал абнаўленьняў: стабільны, бэта альбо экспэрымэнтальны.</translation>
+</message>
+<message>
+<source>Update Channel</source>
+<translation>Канал абнаўленьняў</translation>
+</message>
+<message>
+<source>Version</source>
+<translation>Вэрсія</translation>
+</message>
+<message>
+<source>Multi-desktop</source>
+<translation>Працоўныя сталы</translation>
+</message>
+<message>
+<source>Select behaviour when window is activated with multiple desktops.</source>
+<translation>Абярыце паводзіны пры актывацыі, калі выкарыстоўваюцца некалькімі працоўных сталоў.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::HelpWindowItem</name>
+<message>
+<source>Help</source>
+<translation>Дапамога</translation>
+</message>
+<message>
+<source>All you need to know about Windscribe.</source>
+<translation>Усё, што трэба ведаць пра Windscribe.</translation>
+</message>
+<message>
+<source>Knowledge Base</source>
+<translation>База ведаў</translation>
+</message>
+<message>
+<source>Talk to Garry</source>
+<translation>Пагаварыце з Ґары</translation>
+</message>
+<message>
+<source>Best places to help and get help from other users.</source>
+<translation>Месца, дзе можна дапамагчы іншым альбо атрымаць дапамогу ад супольнасьці.</translation>
+</message>
+<message>
+<source>Community Support</source>
+<translation>Падтрымка супольнасьці</translation>
+</message>
+<message>
+<source>View Debug Log</source>
+<translation>Прагледзець журнал адладкі</translation>
+</message>
+<message>
+<source>Send Debug Log</source>
+<translation>Даслаць журнал адладкі</translation>
+</message>
+<message>
+<source>Sending log...</source>
+<translation>Журнал адладкі адсылаецца...</translation>
+</message>
+<message>
+<source>Sent, thanks!</source>
+<translation>Адаслана, дзякуй!</translation>
+</message>
+<message>
+<source>Failed!</source>
+<translation>Не ўдалося!</translation>
+</message>
+<message>
+<source>Need help? Garry can help you with most issues, go talk to him.</source>
+<translation>Патрэбна дапамога? Ґары можа дапамагчы з большасьцю праблем. Пагаварыце зь ім.</translation>
+</message>
+<message>
+<source>Contact Humans</source>
+<translation>Зьвяжыцеся з аператарам</translation>
+</message>
+<message>
+<source>Have a problem that Garry can&apos;t resolve? Contact human support.</source>
+<translation>Ёсьць праблема, якую Ґары не можа вырашыць? Зьвярніцеся ў службу падтрымкі.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::LookAndFeelWindowItem</name>
+<message>
+<source>Look &amp; Feel</source>
+<translation>Выгляд і зручнасьць</translation>
+</message>
+<message>
+<source>Choose between the classic GUI or the &quot;earless&quot; alternative GUI.</source>
+<translation>Абярыце клясычны інтэрфэйс альбо альтэрнатыўны (&quot;без вушэй&quot;).</translation>
+</message>
+<message>
+<source>App Skin</source>
+<translation>Афармленьне</translation>
+</message>
+<message>
+<source>Customize the background of the main app screen.</source>
+<translation>Наладзьце фон галоўнага экрана праґрамы.</translation>
+</message>
+<message>
+<source>Choose sounds to play when connection events occur.</source>
+<translation>Абярыце гукі для падзеяў злучэньня.</translation>
+</message>
+<message>
+<source>Change location names to your liking.</source>
+<translation>Зьмяніце назвы месцазнаходжаньняў на свой густ.</translation>
+</message>
+<message>
+<source>Rename Locations</source>
+<translation>Зьмяніць назвы</translation>
+</message>
+<message>
+<source>Export</source>
+<translation>Экспартаваць</translation>
+</message>
+<message>
+<source>Import</source>
+<translation>Імпартаваць</translation>
+</message>
+<message>
+<source>Reset</source>
+<translation>Скінуць</translation>
+</message>
+<message>
+<source>Choose between white and black tray icon.</source>
+<translation>Абярыце белы ці чорны значак у сістэмнай панэлі.</translation>
+</message>
+<message>
+<source>Tray Icon Colour</source>
+<translation>Колер значка ў панэлі</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::MacSpoofingGroup</name>
+<message>
+<source>Cannot spoof on &apos;No Interface&apos;</source>
+<translation>Немагчыма падмяніць, калі абраны пункт &apos;Няма інтэрфэйсу&apos;</translation>
+</message>
+<message>
+<source>You can only spoof an existing adapter.</source>
+<translation>Вы можаце падмяніць толькі існуючы адаптар.</translation>
+</message>
+<message>
+<source>Cannot spoof the current interface</source>
+<translation>Немагчыма падмяніць бягучы інтэрфэйс</translation>
+</message>
+<message>
+<source>The current primary interface must match the selected interface to spoof.</source>
+<translation>Бягучы асноўны інтэрфэйс павінен супадаць з абраным, каб выканаць падмену.</translation>
+</message>
+<message>
+<source>No Interface</source>
+<translation>Няма інтэрфэйсу</translation>
+</message>
+<message>
+<source>MAC Spoofing</source>
+<translation>Падмена MAC-адраса</translation>
+</message>
+<message>
+<source>MAC Address</source>
+<translation>MAC-адрас</translation>
+</message>
+<message>
+<source>Interface</source>
+<translation>Інтэрфэйс</translation>
+</message>
+<message>
+<source>Auto-Rotate MAC</source>
+<translation>Аўтаратацыя MAC-адраса</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::NetworkOptionsNetworkWindowItem</name>
+<message>
+<source>Windscribe auto-connects if the device connects to this network.</source>
+<translation>Windscribe падлучыцца аўтаматычна, калі прылада падлучыцца да гэтай сеткі.</translation>
+</message>
+<message>
+<source>Auto-Secure</source>
+<translation>Аўтаматычная абарона</translation>
+</message>
+<message>
+<source>Preferred Protocol</source>
+<translation>Пераважны пратакол</translation>
+</message>
+<message>
+<source>Choose whether to connect using the recommended tunneling protocol, or to specify a protocol of your choice.</source>
+<translation>Абярыце, ці падлучацца з выкарыстаньнем рэкамендаванага пратакола тунэляваньня, ці абіраць пратакол уручную.</translation>
+</message>
+<message>
+<source>Forget Network</source>
+<translation>Забыцца пра сетку</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::NetworkOptionsWindowItem</name>
+<message>
+<source>Network Options</source>
+<translation>Налады сеткі</translation>
+</message>
+<message>
+<source>Mark all newly encountered networks as Secured.</source>
+<translation>Аўтаматычна пазначаць новыя сеткі як абароненыя.</translation>
+</message>
+<message>
+<source>Auto-Secure Networks</source>
+<translation>Аўтаабарона сетак</translation>
+</message>
+<message>
+<source>No Network Detected</source>
+<translation>Сетка не выяўлена</translation>
+</message>
+<message>
+<source>CURRENT NETWORK</source>
+<translation>БЯГУЧАЯ СЕТКА</translation>
+</message>
+<message>
+<source>OTHER NETWORKS</source>
+<translation>ІНШЫЯ СЕТКІ</translation>
+</message>
+<message>
+<source>Secured</source>
+<translation>Абароненая</translation>
+</message>
+<message>
+<source>Unsecured</source>
+<translation>Неабароненая</translation>
+</message>
+<message>
+<source>No Networks Detected.
+Connect to a network first</source>
+<translation>Сеткі не выяўлены.
+Спачатку падлучыцеся да сеткі</translation>
+</message>
+<message>
+<source>New networks are automatically &quot;Secured&quot;. If you tag a network as &quot;Unsecured&quot;, Windscribe will disconnect when the device joins it. Setting a network as &quot;Unsecured&quot; is NOT recommended.</source>
+<translation>Новыя сеткі аўтаматычна пазначаюцца як &quot;Абароненая&quot;. Калі вы пазначаце сетку як &quot;Неабароненая&quot;, Windscribe будзе адлучацца, калі прылада падлучыцца да гэтай сеткі. Пазначаць сетку як &quot;Неабароненая&quot; НЕ рэкамендуецца.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::NewAddressItem</name>
+<message>
+<source>Enter IP or Hostname</source>
+<translation>Увядзіце IP ці імя вузла</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::PacketSizeGroup</name>
+<message>
+<source>Auto-Detect &amp; Generate MTU</source>
+<translation>Аўтаматычнае выяўленье і падбор MTU</translation>
+</message>
+<message>
+<source>Packet Size</source>
+<translation>Памер пакета</translation>
+</message>
+<message>
+<source>Auto</source>
+<translation>Аўта</translation>
+</message>
+<message>
+<source>Manual</source>
+<translation>Уручную</translation>
+</message>
+<message>
+<source>MTU</source>
+<translation>MTU</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::PlanItem</name>
+<message>
+<source>Free</source>
+<translation>Бясплатны</translation>
+</message>
+<message>
+<source>Plan Type</source>
+<translation>Тарыф</translation>
+</message>
+<message>
+<source>Unlimited Data</source>
+<translation>Безьліміт</translation>
+</message>
+<message>
+<source>Custom</source>
+<translation>Адмысловы</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::PreferencesTabControlItem</name>
+<message>
+<source>General</source>
+<translation>Агульныя</translation>
+</message>
+<message>
+<source>Account</source>
+<translation>Уліковы запіс</translation>
+</message>
+<message>
+<source>Connection</source>
+<translation>Злучэньне</translation>
+</message>
+<message>
+<source>R.O.B.E.R.T.</source>
+<translation>R.O.B.E.R.T.</translation>
+</message>
+<message>
+<source>Advanced Options</source>
+<translation>Пашыраныя налады</translation>
+</message>
+<message>
+<source>Help</source>
+<translation>Дапамога</translation>
+</message>
+<message>
+<source>About</source>
+<translation>Аб праґраме</translation>
+</message>
+<message>
+<source>Login</source>
+<translation>Увайсьці</translation>
+</message>
+<message>
+<source>Log Out</source>
+<translation>Выйсьці</translation>
+</message>
+<message>
+<source>Quit</source>
+<translation>Зачыніць</translation>
+</message>
+<message>
+<source>Look &amp; Feel</source>
+<translation>Выгляд і зручнасьць</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::PreferencesWindowItem</name>
+<message>
+<source>Unsaved Changes</source>
+<translation>Незахаваныя зьмены</translation>
+</message>
+<message>
+<source>Discard</source>
+<translation>Адкінуць</translation>
+</message>
+<message>
+<source>You have unsaved changes in edit fields. Do you want to save them?</source>
+<translation>У палях рэдагаваньня ёсьць незахаваныя зьмены. Захаваць іх?</translation>
+</message>
+<message>
+<source>Save</source>
+<translation>Захаваць</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::ProtocolGroup</name>
+<message>
+<source>Auto</source>
+<translation>Аўта</translation>
+</message>
+<message>
+<source>Manual</source>
+<translation>Уручную</translation>
+</message>
+<message>
+<source>Protocol</source>
+<translation>Пратакол</translation>
+</message>
+<message>
+<source>Port</source>
+<translation>Порт</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::ProxyGatewayGroup</name>
+<message>
+<source>Proxy Gateway</source>
+<translation>Проксі-шлюз</translation>
+</message>
+<message>
+<source>Proxy Type</source>
+<translation>Тып проксі</translation>
+</message>
+<message>
+<source>Port</source>
+<translation>Порт</translation>
+</message>
+<message>
+<source>Unable to start proxy server</source>
+<translation>Немагчыма запусціць проксі-сэрвэр</translation>
+</message>
+<message>
+<source>The proxy server couldn&apos;t be started on the requested port. Please try again with a different port.</source>
+<translation>Не ўдалося запусціць проксі-сэрвэр на запытанным порце. Паспрабуйце яшчэ раз зь іншым портам.</translation>
+</message>
+<message>
+<source>Auto</source>
+<translation>Аўта</translation>
+</message>
+<message>
+<source>Only when VPN is connected</source>
+<translation>Толькі з VPN</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::ProxyIpAddressItem</name>
+<message>
+<source>IP</source>
+<translation>IP-адрас</translation>
+</message>
+<message>
+<source>Copied</source>
+<translation>Скапіявана</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::ProxySettingsGroup</name>
+<message>
+<source>Proxy</source>
+<translation>Проксі</translation>
+</message>
+<message>
+<source>Address</source>
+<translation>Адрас</translation>
+</message>
+<message>
+<source>Port</source>
+<translation>Порт</translation>
+</message>
+<message>
+<source>Username</source>
+<translation>Імя карыстальніка</translation>
+</message>
+<message>
+<source>Password</source>
+<translation>Пароль</translation>
+</message>
+<message>
+<source>Invalid proxy address</source>
+<translation>Няправільны адрас проксі-сэрвэра</translation>
+</message>
+<message>
+<source>Invalid proxy port</source>
+<translation>Няправільны порт проксі-сэрвэра</translation>
+</message>
+<message>
+<source>Proxy port is invalid. Please enter a valid port in the range 0-65535.</source>
+<translation>Няправільны порт проксі-сэрвэра. Увядзіце карэктны порт у межах 0-65535.</translation>
+</message>
+<message>
+<source>Proxy address is invalid. Please enter a valid IP address.</source>
+<translation>Няправільны адрас проксі-сэрвэра. Увядзіце карэктны IP-адрас.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::ProxySettingsWindowItem</name>
+<message>
+<source>Proxy Settings</source>
+<translation>Налады проксі</translation>
+</message>
+<message>
+<source>If your network has a LAN proxy, configure it here. Please note these proxy settings are only utilized when connecting with the TCP protocol.</source>
+<translation>Калі ў вашай сетцы выкарыстоўваецца LAN-проксі, наладзьце яго тут. Гэтыя налады выкарыстоўваюцца толькі пры падлучэньні па пратаколе TCP.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::RobertItem</name>
+<message>
+<source>Blocking</source>
+<translation>Заблякавана</translation>
+</message>
+<message>
+<source>Allowing</source>
+<translation>Дазволена</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::RobertWindowItem</name>
+<message>
+<source>R.O.B.E.R.T.</source>
+<translation>R.O.B.E.R.T.</translation>
+</message>
+<message>
+<source>R.O.B.E.R.T. is a customizable server-side domain and IP blocking tool. Select the block lists you wish to apply on all your devices by toggling the switch.</source>
+<translation>R.O.B.E.R.T. — гэта наладжвальны інструмэнт блякаваньня дамэнаў і IP-адрасоў на баку сэрвэра. Абярыце сьпісы блякаваньня, якія трэба ўжыць на ўсіх сваіх прыладах, пераключыўшы адпаведныя пераключальнікі.</translation>
+</message>
+<message>
+<source>Could not retrieve R.O.B.E.R.T. preferences from server. Try again later.</source>
+<translation>Не ўдалося атрымаць налады R.O.B.E.R.T. з сэрвэра. Паўтарыце спробу пазьней.</translation>
+</message>
+<message>
+<source>Login to view or change R.O.B.E.R.T preferences</source>
+<translation>Увайдзіце, каб праглядзець альбо зьмяніць налады R.O.B.E.R.T</translation>
+</message>
+<message>
+<source>Login</source>
+<translation>Увайсьці</translation>
+</message>
+<message>
+<source>Manage Custom Rules</source>
+<translation>Кіраваць уласнымі правіламі</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SearchLineEditItem</name>
+<message>
+<source>Search</source>
+<translation>Пошук</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SecureHotspotGroup</name>
+<message>
+<source>Secure Hotspot</source>
+<translation>Абаронены хотспот</translation>
+</message>
+<message>
+<source>Secure hotspot is not supported by your network adapter.</source>
+<translation>Абароненая кропка доступу не падтрымліваецца вашым сеткавым адаптарам.</translation>
+</message>
+<message>
+<source>Secure hotspot is not supported for IKEv2 protocol.</source>
+<translation>Абароненая кропка доступу не працуе з пратаколам IKEv2.</translation>
+</message>
+<message>
+<source>Share your secure Windscribe connection wirelessly.</source>
+<translation>Падзяліцеся абароненым злучэньнем Windscribe праз Wi-Fi.</translation>
+</message>
+<message>
+<source>Enter SSID</source>
+<translation>Увядзіце SSID</translation>
+</message>
+<message>
+<source>Password</source>
+<translation>Пароль</translation>
+</message>
+<message>
+<source>At least 8 characters</source>
+<translation>Ня менш за 8 знакаў</translation>
+</message>
+<message>
+<source>To turn on Secure Hotspot, please turn off split tunneling or use exclusive mode.</source>
+<translation>Каб уключыць абароненую кропку доступу, адключыце &quot;Падзел тунэлю&quot; альбо скарыстайцеся выключным рэжымам.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SelectFileItem</name>
+<message>
+<source>[no selection]</source>
+<translation>[не абрана]</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SoundsGroup</name>
+<message>
+<source>Sound Notifications</source>
+<translation>Гукавыя апавяшчэньні</translation>
+</message>
+<message>
+<source>None</source>
+<translation>Няма</translation>
+</message>
+<message>
+<source>When Disconnected</source>
+<translation>Калі адлучана</translation>
+</message>
+<message>
+<source>Bundled</source>
+<translation>Стандартны</translation>
+</message>
+<message>
+<source>Custom</source>
+<translation>Уласны</translation>
+</message>
+<message>
+<source>Select a sound</source>
+<translation>Абярыце гук</translation>
+</message>
+<message>
+<source>When Connected</source>
+<translation>Калі падлучана</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SplitTunnelingAddressesGroup</name>
+<message>
+<source>IP or hostname already exists. Please enter a new IP or hostname.</source>
+<translation>IP-адрас альбо імя вузла ўжо існуе. Увядзіце іншы IP-адрас альбо імя вузла.</translation>
+</message>
+<message>
+<source>Incorrect IP address/mask combination. Please enter a valid hostname or IP address in plain or CIDR notation.</source>
+<translation>Няправільнае спалучэньне IP-адраса і маскі. Увядзіце правільнае імя вузла альбо IP-адрас без маскі ці ў фармаце CIDR.</translation>
+</message>
+<message>
+<source>This IP address or range is reserved by Windscribe and can not be changed.</source>
+<translation>Гэты IP-адрас альбо дыяпазон адрасоў зарэзэрваваны Windscribe і не падлягае зьмене.</translation>
+</message>
+<message>
+<source>There are too many hostnames in the list. Please remove some before adding more.</source>
+<translation>У сьпісе зашмат імёнаў вузлоў. Выдаліце некалькі, перш чым дадаць новыя.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SplitTunnelingAddressesWindowItem</name>
+<message>
+<source>IPs &amp; Hostnames</source>
+<translation>IP-адрасы і імёны вузлоў</translation>
+</message>
+<message>
+<source>Enter the IP and/or hostnames you wish to include in or exclude from the VPN tunnel below.</source>
+<translation>Увядзіце ніжэй IP-адрасы і/ці імёны вузлоў, якія трэба ўключыць у VPN-тунель альбо выключыць з яго.</translation>
+</message>
+<message>
+<source>Please log in to modify split tunneling rules.</source>
+<translation>Увайдзіце, каб зьмяняць правілы падзелу тунэлю.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SplitTunnelingAppsGroup</name>
+<message>
+<source>There are too many apps in the list. Please remove some before adding more.</source>
+<translation>У сьпісе зашмат праґрам. Выдаліце некалькі, перш чым дадаць новыя.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SplitTunnelingAppsItem</name>
+<message>
+<source>Search/Add Apps</source>
+<translation>Пошук/Даданьне</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SplitTunnelingAppsWindowItem</name>
+<message>
+<source>Apps</source>
+<translation>Праґрамы</translation>
+</message>
+<message>
+<source>Add the apps you wish to include in or exclude from the VPN tunnel below.</source>
+<translation>Увядзіце ніжэй праґрамы, якія трэба ўключыць у VPN-тунель альбо выключыць з яго.</translation>
+</message>
+<message>
+<source>Please log in to modify split tunneling rules.</source>
+<translation>Увайдзіце, каб зьмяняць правілы падзелу тунэлю.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SplitTunnelingGroup</name>
+<message>
+<source>Service Not Installed</source>
+<translation>Служба не ўсталявана</translation>
+</message>
+<message>
+<source>The split tunneling driver is not installed.  To enable this feature, try reinstalling the Windscribe application.
+
+If the reinstall does not help, please contact Windscribe support for assistance.</source>
+<translation>Драйвэр падзелу тунэлю не ўсталяваны.  Каб уключыць гэтую функцыю, пераўсталюйце праґраму Windscribe.
+
+Калі пераўсталёўка не дапаможа, зьвярніцеся ў службу падтрымкі Windscribe.</translation>
+</message>
+<message>
+<source>Split Tunneling</source>
+<translation>Падзел тунэлю</translation>
+</message>
+<message>
+<source>Mode</source>
+<translation>Рэжым</translation>
+</message>
+<message>
+<source>Exclusive</source>
+<translation>Выключны</translation>
+</message>
+<message>
+<source>Inclusive</source>
+<translation>Уключны</translation>
+</message>
+<message>
+<source>Apps</source>
+<translation>Праґрамы</translation>
+</message>
+<message>
+<source>IPs &amp; Hostnames</source>
+<translation>IP-адрасы і імёны вузлоў</translation>
+</message>
+<message>
+<source>When enabled, selected apps, IPs, and hostnames will not go through Windscribe when connected.</source>
+<translation>Калі ўключана, абраныя праґрамы, IP-адрасы і імёны вузлоў не будуць выкарыстоўваць VPN-тунэль Windscribe.</translation>
+</message>
+<message>
+<source>When enabled, only selected apps, IPs, and hostnames will go through Windscribe when connected.</source>
+<translation>Калі ўключана, толькі абраныя праґрамы, IP-адрасы і імёны вузлоў будуць выкарыстоўваць VPN-тунэль Windscribe.</translation>
+</message>
+</context>
+<context>
+<name>PreferencesWindow::SplitTunnelingWindowItem</name>
+<message>
+<source>Split Tunneling</source>
+<translation>Падзел тунэлю</translation>
+</message>
+<message>
+<source>Include or exclude apps and hostnames from the VPN tunnel.</source>
+<translation>Уключыць альбо выключыць праґрамы і імёны вузлоў у VPN-тунэлі.</translation>
+</message>
+<message>
+<source>The Windscribe split tunneling system extension must be enabled for this feature to function. Please enable it in System Settings.</source>
+<translation>Для працы гэтай функцыі неабходна ўключыць сістэмны дадатак падзелу тунэлю Windscribe. Уключыце яго ў сістэмных наладах.</translation>
+</message>
+</context>
+<context>
+<name>ProtocolWindow::ProtocolLineItem</name>
+<message>
+<source>NEXT UP IN %1s</source>
+<translation>НАСТУПНАЕ ПРАЗ %1 с</translation>
+</message>
+<message>
+<source>Connected to</source>
+<translation>Падлучана да</translation>
+</message>
+<message>
+<source>Failed</source>
+<translation>Не ўдалося</translation>
+</message>
+</context>
+<context>
+<name>ProtocolWindow::ProtocolPromptItem</name>
+<message>
+<source>Cutting-edge protocol.</source>
+<translation>Найсучасны пратакол.</translation>
+</message>
+<message>
+<source>An IPsec based tunneling protocol.</source>
+<translation>Тунэль на аснове IPsec.</translation>
+</message>
+<message>
+<source>Balanced speed and security.</source>
+<translation>Балянс хуткасьці і бясьпекі.</translation>
+</message>
+<message>
+<source>Use it if OpenVPN UDP fails.</source>
+<translation>Калі OpenVPN UDP не працуе.</translation>
+</message>
+<message>
+<source>Disguises traffic as HTTPS with TLS.</source>
+<translation>Маскіруе трафік пад HTTPS (TLS).</translation>
+</message>
+<message>
+<source>Wraps traffic with web sockets.</source>
+<translation>Абгортвае трафік у WebSocket.</translation>
+</message>
+<message>
+<source>Change Protocol</source>
+<translation>Зьмяніць пратакол</translation>
+</message>
+<message>
+<source>Quickly re-connect using a different protocol.</source>
+<translation>Хутка перападлучыцеся, выкарыстоўваючы іншы пратакол.</translation>
+</message>
+<message>
+<source>Connection Failure!</source>
+<translation>Злучэньне не ўдалося!</translation>
+</message>
+<message>
+<source>The protocol you’ve chosen has failed to connect. Windscribe will attempt to reconnect using the first protocol below.</source>
+<translation>Не ўдалося падлучыцца праз абраны пратакол. Windscribe паспрабуе перападлучыцца, выкарыстоўваючы першы пратакол ніжэй.</translation>
+</message>
+<message>
+<source>Cancel</source>
+<translation>Скасаваць</translation>
+</message>
+</context>
+<context>
+<name>QObject</name>
+<message>
+<source>Custom</source>
+<translation>Уласны</translation>
+</message>
+<message>
+<source>OS Default</source>
+<translation>Сістэмны</translation>
+</message>
+<message>
+<source>UNKNOWN</source>
+<translation>НЕВЯДОМА</translation>
+</message>
+<message>
+<source>Geography</source>
+<translation>Геаграфія</translation>
+</message>
+<message>
+<source>Alphabet</source>
+<translation>Альфабэт</translation>
+</message>
+<message>
+<source>Latency</source>
+<translation>Затрымка</translation>
+</message>
+<message>
+<source>Manual</source>
+<translation>Ручны</translation>
+</message>
+<message>
+<source>Auto</source>
+<translation>Аўта</translation>
+</message>
+<message>
+<source>Always On</source>
+<translation>Заўсёды</translation>
+</message>
+<message>
+<source>Before Connection</source>
+<translation>Перад палучэньнем</translation>
+</message>
+<message>
+<source>After Connection</source>
+<translation>Пасьля палучэньня</translation>
+</message>
+<message>
+<source>None</source>
+<translation>Няма</translation>
+</message>
+<message>
+<source>Auto-detect</source>
+<translation>Аўтавыяўленьне</translation>
+</message>
+<message>
+<source>Release</source>
+<translation>Release</translation>
+</message>
+<message>
+<source>Beta</source>
+<translation>Beta</translation>
+</message>
+<message>
+<source>Guinea Pig</source>
+<translation>Guinea Pig</translation>
+</message>
+<message>
+<source>Internal</source>
+<translation>Internal</translation>
+</message>
+<message>
+<source>Exclude</source>
+<translation>Выключны</translation>
+</message>
+<message>
+<source>Include</source>
+<translation>Уключны</translation>
+</message>
+<message>
+<source>Alpha</source>
+<translation>Альфа</translation>
+</message>
+<message>
+<source>Van Gogh</source>
+<translation>Ван Гог</translation>
+</message>
+<message>
+<source>Failed to open file</source>
+<translation>Не ўдалося адчыніць файл</translation>
+</message>
+<message>
+<source>Invalid config format</source>
+<translation>Некарэктны фармат канфіґурацыі</translation>
+</message>
+<message>
+<source>Missing &quot;Interface&quot; section</source>
+<translation>Адсутнічае разьдзел &quot;Interface&quot;</translation>
+</message>
+<message>
+<source>Missing &quot;Peer&quot; section</source>
+<translation>Адсутнічае разьдзел &quot;Peer&quot;</translation>
+</message>
+<message>
+<source>Missing &quot;PrivateKey&quot; in the &quot;Interface&quot; section</source>
+<translation>Адсутнічае &quot;PrivateKey&quot; у разьдзеле &quot;Interface&quot;</translation>
+</message>
+<message>
+<source>Missing &quot;Address&quot; in the &quot;Interface&quot; section</source>
+<translation>Адсутнічае &quot;Address&quot; у разьдзеле &quot;Interface&quot;</translation>
+</message>
+<message>
+<source>Missing &quot;DNS&quot; in the &quot;Interface&quot; section</source>
+<translation>Адсутнічае &quot;DNS&quot; у разьдзеле &quot;Interface&quot;</translation>
+</message>
+<message>
+<source>Missing &quot;PublicKey&quot; in the &quot;Peer&quot; section</source>
+<translation>Адсутнічае &quot;PublicKey&quot; у разьдзеле &quot;Peer&quot;</translation>
+</message>
+<message>
+<source>Missing &quot;Endpoint&quot; in the &quot;Peer&quot; section</source>
+<translation>Адсутнічае &quot;Endpoint&quot; у разьдзеле &quot;Peer&quot;</translation>
+</message>
+<message>
+<source>Static IPs</source>
+<translation>Статычныя IP-адрасы</translation>
+</message>
+<message>
+<source>Your application version is no longer supported. Please update to continue using Windscribe.</source>
+<translation>Вашая версія праґрамы больш не падтрымліваецца. Абнавіце Windscribe, каб працягнуць карыстаньне.</translation>
+</message>
+<message>
+<source>Please upgrade to a Pro account to continue using Windscribe.</source>
+<translation>Абнавіце ўліковы запіс да Pro, каб працягнуць карыстацца Windscribe.</translation>
+</message>
+<message>
+<source>Your original account %1 has expired. Creating multiple accounts to bypass free tier limitations is prohibited. Please login into the original account and wait until the bandwidth is reset. You can also upgrade to Pro.</source>
+<translation>Тэрмін дзеяньня вашага першапачатковага ўліковага запісу %1 скончыўся. Стварэньне некалькіх уліковых запісаў для абыходу абмежаваньняў бясплатнага тарыфу забаронена. Увайдзіце ў першапачатковы ўліковы запіс і пачакайце, пакуль ліміт трафіку не будзе адноўлены. Вы таксама можаце абнавіць уліковы запіс да Pro.</translation>
+</message>
+<message>
+<source>Your account is disabled for abuse.</source>
+<translation>Ваш уліковы запіс заблякаваны за злоўжываньне.</translation>
+</message>
+<message>
+<source>Firewall Always On</source>
+<translation>Брандмаўэр заўсёды ўключаны</translation>
+</message>
+<message>
+<source>Can&apos;t turn the firewall off because &quot;Always On&quot; mode is enabled</source>
+<translation>Немагчыма выключыць брандмаўэр, пакуль ўключаны рэжым &quot;Заўсёды&quot;</translation>
+</message>
+<message>
+<source>Windscribe is already running on your computer, but appears to not be responding.</source>
+<translation>Windscribe ужо запушчаны, але не адказвае.</translation>
+</message>
+<message>
+<source>You may need to kill the non-responding Windscribe app or reboot your computer to fix the issue.</source>
+<translation>Магчына, трэба прымусова закрыць праґраму Windscribe, якая не адказвае, альбо перазапусціць кампутар.</translation>
+</message>
+<message>
+<source>One or more files in the Windscribe application bundle have been suspiciously modified. Please re-install Windscribe.</source>
+<translation>Адзін альбо некалькі файлаў праґрамы Windscribe былі падазрона зьменены. Пераўсталюйце Windscribe.</translation>
+</message>
+<message>
+<source>White</source>
+<translation>Белы</translation>
+</message>
+<message>
+<source>Black</source>
+<translation>Чорны</translation>
+</message>
+<message>
+<source>Forced</source>
+<translation>Прымусовы</translation>
+</message>
+<message>
+<source>Move spaces</source>
+<translation>Перамяшчаць прасторы</translation>
+</message>
+<message>
+<source>Move window</source>
+<translation>Перамяшчаць акно</translation>
+</message>
+<message>
+<source>Duplicate</source>
+<translation>Дубляваць</translation>
+</message>
+<message>
+<source>Local DNS</source>
+<translation>Лякальны DNS</translation>
+</message>
+<message>
+<source>Stretch</source>
+<translation>Расьцягваць</translation>
+</message>
+<message>
+<source>Fill</source>
+<translation>Запаўняць</translation>
+</message>
+<message>
+<source>Tile</source>
+<translation>Замошчваць</translation>
+</message>
+<message>
+<source>Always On+</source>
+<translation>Заўсёды+</translation>
+</message>
+<message>
+<source>Custom configs</source>
+<translation>Уласныя канфіґурацыі</translation>
+</message>
+<message>
+<source>Random IP</source>
+<translation>Выпадковы IP-адрас</translation>
+</message>
+</context>
+<context>
+<name>QWidget</name>
+<message>
+<source>Unknown Config Error</source>
+<translation>Невядомая памылка канфіґурацыі</translation>
+</message>
+<message>
+<source>File Sharing Frowned Upon</source>
+<translation>Сумеснае выкарыстаньне файлаў не ўхваляецца</translation>
+</message>
+</context>
+<context>
+<name>ServerRatingsTooltip</name>
+<message>
+<source>Rate speed</source>
+<translation>Ацаніць хуткасьць</translation>
+</message>
+</context>
+<context>
+<name>SharingFeatures::SharingFeaturesWindowItem</name>
+<message>
+<source>Sharing Features</source>
+<translation>Агульны доступ</translation>
+</message>
+<message>
+<source>Proxy Gateway</source>
+<translation>Проксі-шлюз</translation>
+</message>
+<message>
+<source>Secure Hotspot</source>
+<translation>Абароненая кропка доступу</translation>
+</message>
+</context>
+<context>
+<name>TrayIcon</name>
+<message>
+<source>Connect</source>
+<translation>Падлучыцца</translation>
+</message>
+<message>
+<source>Disconnect</source>
+<translation>Адлучыцца</translation>
+</message>
+<message>
+<source>Locations</source>
+<translation>Месцазнаходжаньні</translation>
+</message>
+<message>
+<source>Static IPs</source>
+<translation>Статычныя IP-адрасы</translation>
+</message>
+<message>
+<source>Custom configs</source>
+<translation>Уласныя канфіґурацыі</translation>
+</message>
+<message>
+<source>Preferences</source>
+<translation>Налады</translation>
+</message>
+<message>
+<source>Help</source>
+<translation>Дапамога</translation>
+</message>
+<message>
+<source>Quit Windscribe</source>
+<translation>Зачыніць Windscribe</translation>
+</message>
+<message>
+<source>Favourites</source>
+<translation>Абранае</translation>
+</message>
+<message>
+<source>Show app</source>
+<translation>Паказаць праґраму</translation>
+</message>
+</context>
+<context>
+<name>TwoFactorAuthWindow::TwoFactorAuthOkButton</name>
+<message>
+<source>Add</source>
+<translation>Дадаць</translation>
+</message>
+<message>
+<source>Login</source>
+<translation>Увайсьці</translation>
+</message>
+</context>
+<context>
+<name>TwoFactorAuthWindow::TwoFactorAuthWindowItem</name>
+<message>
+<source>Two-factor Auth</source>
+<translation>Двухфактарная праверка сапраўднасьці</translation>
+</message>
+<message>
+<source>Use your app to get an authentication code, and enter it below</source>
+<translation>Атрымайце код у праґраме праверкі сапраўднасьці і ўвядзіце яго ніжэй</translation>
+</message>
+<message>
+<source>Please provide a 2FA code</source>
+<translation>Увядзіце код 2FA</translation>
+</message>
+<message>
+<source>Invalid 2FA code, please try again</source>
+<translation>Няправільны код 2FA, паспрабуйце зноў</translation>
+</message>
+</context>
+<context>
+<name>UpdateApp::UpdateAppItem</name>
+<message>
+<source>v</source>
+<translation>v</translation>
+</message>
+<message>
+<source>Update</source>
+<translation>Абнавіць</translation>
+</message>
+</context>
+<context>
+<name>UpdateWindowItem</name>
+<message>
+<source>Updating </source>
+<translation>Ідзе абнаўленьне </translation>
+</message>
+<message>
+<source>Your update is in progress, hang in there...</source>
+<translation>Ідзе абнаўленьне, пачакайце...</translation>
+</message>
+<message>
+<source>Cancel</source>
+<translation>Скасаваць</translation>
+</message>
+<message>
+<source>Later</source>
+<translation>Пазьней</translation>
+</message>
+<message>
+<source>Update</source>
+<translation>Абнавіць</translation>
+</message>
+<message>
+<source>Windscribe will download the update, then terminate active connections and restart automatically.</source>
+<translation>Windscribe спампуе абнаўленьне, перапыніць актыўныя злучэньні і аўтаматычна перазапусьціцца.</translation>
+</message>
+<message>
+<source>Windscribe will download and install the update, which may take several minutes. Your computer will restart after the update.</source>
+<translation>Windscribe спампуе і ўсталюе абнаўленьне, што можа заняць некалькі хвілін. Пасьля абнаўленьня кампутар перазапусьціцца.</translation>
+</message>
+</context>
+<context>
+<name>UpgradeBanner</name>
+<message>
+<source>Unlock full access to Windscribe</source>
+<translation>Атрымайце поўны доступ да Windscribe</translation>
+</message>
+<message>
+<source>Go Pro for unlimited everything</source>
+<translation>Перайдзіце на Pro без абмежаваньняў</translation>
+</message>
+</context>
+<context>
+<name>UpgradeWidget::UpgradeWidgetItem</name>
+<message>
+<source>Get more data</source>
+<translation>Болей трафіку</translation>
+</message>
+<message>
+<source>%1 left</source>
+<translation>Засталося %1</translation>
+</message>
+<message>
+<source>0 days left</source>
+<translation>Засталося 0 дзён</translation>
+</message>
+<message>
+<source>1 day left</source>
+<translation>Застаўся 1 дзень</translation>
+</message>
+<message>
+<source>2 days left</source>
+<translation>Засталося 2 дні</translation>
+</message>
+<message>
+<source>3 days left</source>
+<translation>Засталося 3 дні</translation>
+</message>
+<message>
+<source>4 days left</source>
+<translation>Засталося 4 дні</translation>
+</message>
+<message>
+<source>5 days left</source>
+<translation>Засталося 2 дзён</translation>
+</message>
+<message>
+<source>%1 days left</source>
+<translation>Засталося %1 дзён</translation>
+</message>
+<message>
+<source>Login</source>
+<translation>Увайсьці</translation>
+</message>
+<message>
+<source>Renew</source>
+<translation>Абнавіць</translation>
+</message>
+</context>
+<context>
+<name>UpgradeWindow::UpgradeWindowItem</name>
+<message>
+<source>You&apos;re out of data!</source>
+<translation>У вас скончыўся трафік!</translation>
+</message>
+<message>
+<source>Don&apos;t leave your front door open. Upgrade or wait until next month to get your monthly data allowance back.</source>
+<translation>Не пакідайце дзьверы адчыненымі. Перайдзіце на Pro альбо пачакайце да наступнага месяца, калі адновіцца штомесячны ліміт трафіку.</translation>
+</message>
+<message>
+<source>Get more data</source>
+<translation>Атрымаць трафік</translation>
+</message>
+<message>
+<source>I&apos;m broke</source>
+<translation>Грошай няма</translation>
+</message>
+</context>
+<context>
+<name>gui_locations::LocationsModel</name>
+<message>
+<source>Best Location</source>
+<translation>Найлепшае месцазнаходжаньне</translation>
+</message>
+</context>
+</TS>

--- a/src/installer/common/CMakeLists.txt
+++ b/src/installer/common/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_AUTORCC ON)
 
 set(WINDSCRIBE_TS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_installer_ar.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_installer_be.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_installer_cs.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_installer_de.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_installer_el.ts

--- a/src/installer/common/translations/windscribe_installer_be.ts
+++ b/src/installer/common/translations/windscribe_installer_be.ts
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="be_BY">
+<context>
+    <name>AlertWindow</name>
+    <message>
+        <source>ESC</source>
+        <translation>ESC</translation>
+    </message>
+</context>
+<context>
+    <name>InitialWindow</name>
+    <message>
+        <source>Read EULA</source>
+        <translation>Чытаць Карыстальніцкае пагадненьне</translation>
+    </message>
+</context>
+<context>
+    <name>InstallButton</name>
+    <message>
+        <source>Install</source>
+        <translation>Усталяваць</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>Invalid path</source>
+        <translation>Няправільны шлях</translation>
+    </message>
+    <message>
+        <source>Installation failed</source>
+        <translation>Усталяваньне не ўдалося</translation>
+    </message>
+    <message>
+        <source>The installation could not be completed successfully. Please contact our Technical Support.</source>
+        <translation>Не ўдалося завяршыць усталяваньне. Зьвярніцеся ў службу тэхнічнай падтрымкі.</translation>
+    </message>
+    <message>
+        <source>Select a folder in the list below and click OK.</source>
+        <translation>Абярыце каталёґ з сьпіса ніжэй і націсьніце ОК.</translation>
+    </message>
+    <message>
+        <source>The specified installation path is not on the system drive. To ensure the security of the application, and your system, it must be installed on the same drive as Windows. The installation folder has been reset to the default.</source>
+        <translation>Абраны шлях усталяваньня знаходзіцца не на сыстэмным дыску. Каб забясьпечыць бясьпеку праґрамы і вашай сыстэмы, яе трэба ўсталяваць на той жа дыск, што і Windows. Каталёґ ўсталяваньня быў вернуты да прадвызначанага.</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>Добра</translation>
+    </message>
+    <message>
+        <source>The installation was cancelled. Administrator privileges are required to install the application.</source>
+        <translation>Усталяваньне было адменена. Для ўсталяваньня праґрамы патрэбныя правы адміністратара.</translation>
+    </message>
+    <message>
+        <source>Windscribe is running and could not be closed. Please close the application manually and try again.</source>
+        <translation>Windscribe працуе, і яго не ўдалося закрыць. Закрыйце праґраму ўручную і паспрабуйце зноў.</translation>
+    </message>
+    <message>
+        <source>Quit Windscribe Installer?</source>
+        <translation>Выйсьці з усталёўніка Windscribe?</translation>
+    </message>
+    <message>
+        <source>The installer could not connect to the privileged helper tool. Please try again.</source>
+        <translation>Усталёўніку не ўдалося падлучыцца да дапаможнай службы з правамі адміністратара. Паспрабуйце яшчэ раз.</translation>
+    </message>
+    <message>
+        <source>An existing installation of Windscribe could not be removed. Please uninstall the application manually and try again.</source>
+        <translation>Не ўдалося выдаліць існую ўсталёўку Windscribe. Выдаліце праґраму ўручную і паспрабуйце зноў.</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Зачыніць</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Скасаваць</translation>
+    </message>
+    <message>
+        <source>You don&apos;t have sufficient permissions to run this application. Administrative privileges are required to install Windscribe.</source>
+        <translation>У вас недастаткова правоў, каб запусьціць гэтую праґраму. Для ўсталёўваньня Windscribe патрэбныя правы адміністратара.</translation>
+    </message>
+    <message>
+        <source>The uninstaller for the existing installation of Windscribe could not be found. Please uninstall the application manually and try again.</source>
+        <translation>Не ўдалося знайсьці праґраму для выдаленьня існай усталёўкі Windscribe. Выдаліце праґраму ўручную і праспрабуйце зноў.</translation>
+    </message>
+    <message>
+        <source>Security Warning</source>
+        <translation>Папярэджаньне бясьпекі</translation>
+    </message>
+    <message>
+        <source>Installation to a custom folder may allow an attacker to tamper with the Windscribe application. To ensure the security of the application, and your system, we strongly recommend you install to the default location in the &apos;Program Files&apos; folder. Click OK to continue with the custom folder or Cancel to use the default location.</source>
+        <translation>Усталёўваньне ва ўласны каталёґ можа дазволіць зламысьніку зьмяніць файлы праґрамы Windscribe. Каб забясьпечыць бясьпеку праґрамы і вашай сыстэмы, мы настойліва раім усталёўваць яе ў прадвызначаны каталёґ &quot;Program Files&quot;. Націсьніце &quot;Добра&quot;, каб працягнуць з уласным каталёґам, альбо &quot;Скасаваць&quot;, каб выкарыстоўваць прадвызначаны каталёґ.</translation>
+    </message>
+    <message>
+        <source>Your current username is &apos;windscribe&apos;, which is needed by the Windscribe app. Windscribe can&apos;t be installed.</source>
+        <translation>Ваша бягучае імя карыстальніка — &quot;windscribe&quot;, яно патрэбнае праграме Windscribe, таму ўсталёўка немагчымая.</translation>
+    </message>
+    <message>
+        <source>Installation to your custom folder was unsuccessful. Please uninstall the application manually, ensure no applications are accessing the custom folder, and try again.</source>
+        <translation>Усталёўваньне ва ўласны каталёґ не ўдалося. Выдаліце праґраму ўручную, пераканайцеся, што ніякія праґрамы не маюць доступу да гэтага каталёґа, і паспрабуйце яшчэ раз.</translation>
+    </message>
+    <message>
+        <source>The custom installation folder could not be deleted. Please uninstall the application manually, ensure no applications are accessing the custom folder, and try again.</source>
+        <translation>Не ўдалося выдаліць уласны каталёґ ўсталёўваньня. Выдаліце праґраму ўручную, пераканайцеся, што ніякія праґрамы не маюць доступу да гэтага каталёґа, і паспрабуйце яшчэ раз.</translation>
+    </message>
+    <message>
+        <source>The custom installation folder is not empty. As a security precaution, Windscribe can only be installed to an empty folder. Please delete all files from the folder and try again.</source>
+        <translation>Уласны каталёґ усталёўваньня не пусты. У якасьці меры бясьпекі Windscribe можна ўсталяваць толькі ў пусты каталёґ. Выдаліце ўсе файлы з каталёґа і паспрабуйце яшчэ раз.</translation>
+    </message>
+</context>
+<context>
+    <name>ProgressDisplay</name>
+    <message>
+        <source>%1%</source>
+        <translation>%1%</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Windscribe Installer</source>
+        <translation>Усталёўнік Windscribe</translation>
+    </message>
+    <message>
+        <source>This version of the Windscribe app will not operate correctly on your PC.  Please download the &apos;ARM64&apos; version from the Windscribe website to ensure optimal compatibility and performance.</source>
+        <translation>Гэта вэрсія праґрамы Windscribe не будзе належным чынам працаваць на вашым ПК.  Спампуйце вэрсію ARM64 з вэб-сайту Windscribe, каб забясьпечыць сумяшчальнасьць і хуткасьць працы.</translation>
+    </message>
+    <message>
+        <source>Windscribe Install Options</source>
+        <translation>Парамэтры ўсталёўкі Windscribe</translation>
+    </message>
+    <message>
+        <source>The Windscribe installer accepts the following optional commmand-line parameters: </source>
+        <translation>Усталёўнік Windscribe прымае наступныя неабавязковыя парамэтры каманднага радка: </translation>
+    </message>
+    <message>
+        <source>Show this information.</source>
+        <translation>Паказаць інфармацыю.</translation>
+    </message>
+    <message>
+        <source>Do not launch the application after installation.</source>
+        <translation>Не запускаць праґраму пасьля ўсталёўваньня.</translation>
+    </message>
+    <message>
+        <source>Delete existing preferences, logs, and other data, if they exist.</source>
+        <translation>Выдаліць існыя налады, журналы і іншыя дадзеныя, калі яны ёсьць.</translation>
+    </message>
+    <message>
+        <source>Overrides the default installation directory. Installation directory must be on the system drive.</source>
+        <translation>Перавызначае прадвызначаны каталёґ усталёўкі. Ён павінен знаходзіцца на сыстэмным дыску.</translation>
+    </message>
+    <message>
+        <source>Sets the username the application will use to automatically log in when first launched.</source>
+        <translation>Задае імя карыстальніка, якое праґрама будзе выкарыстоўваць для аўтаматычнага ўваходу пры першым запуску.</translation>
+    </message>
+    <message>
+        <source>Sets the password the application will use to automatically log in when first launched.</source>
+        <translation>Задае пароль, які праґрама будзе выкарыстоўваць для аўтаматычнага ўваходу пры першым запуску.</translation>
+    </message>
+    <message>
+        <source>Windscribe Install Error</source>
+        <translation>Памылка ўсталёўвання Windscribe</translation>
+    </message>
+    <message>
+        <source>The -dir parameter was specified but the directory path was not.</source>
+        <translation>Парамэтар -dir быў пазначаны, але шлях да каталёґу не зададзены.</translation>
+    </message>
+    <message>
+        <source>The -username parameter was specified but the username was not.</source>
+        <translation>Парамэтар -username быў пазначаны, але імя карыстальніка не зададзена.</translation>
+    </message>
+    <message>
+        <source>The -password parameter was specified but the password was not.</source>
+        <translation>Парамэтар -password быў пазначаны, але пароль не зададзены.</translation>
+    </message>
+    <message>
+        <source>Incorrect number of arguments passed to installer.</source>
+        <translation>Усталёўніку перададзена няправільная колькосьць арґумэнтаў.</translation>
+    </message>
+    <message>
+        <source>Use the -help argument to see available arguments and their format.</source>
+        <translation>Выкарыстоўвайце парамэтар -help, каб паглядзець даступныя парамэтры і іх фармат.</translation>
+    </message>
+    <message>
+        <source>The specified installation path is not on the system drive.  To ensure the security of the application, and your system, it must be installed on the same drive as Windows.</source>
+        <translation>Пазначаны шлях усталёўкі не разьмешчаны на сыстэмным дыску.  Каб забясьпечыць бясьпеку праґрамы і вашай сыстэмы, яе неабходна ўсталяваць на той жа дыск, што і Windows.</translation>
+    </message>
+    <message>
+        <source>A username was specified but its corresponding password was not provided.</source>
+        <translation>Імя карыстальніка было пазначана, але адпаведны пароль не ўказаны.</translation>
+    </message>
+    <message>
+        <source>Your username should not be an email address. Please try again.</source>
+        <translation>Імя карыстальніка не павінна быць адрасам электроннай пошты. Паспрабуйце яшчэ раз.</translation>
+    </message>
+    <message>
+        <source>A password was specified but its corresponding username was not provided.</source>
+        <translation>Пароль быў пазначаны, але адпаведнае імя карыстальніка не ўказана.</translation>
+    </message>
+    <message>
+        <source>The installer was unable to determine if it is running with administrator rights.  Please report this failure to Windscribe support.</source>
+        <translation>Усталёўнік не здолеў вызначыць, ці запушчаны ён з правамі адміністратара.  Паведаміце пра гэтую памылку ў службу падтрымкі Windscribe.</translation>
+    </message>
+    <message>
+        <source>Instructs the installer to hide its user interface.</source>
+        <translation>Загадвае ўсталёўніку схаваць карыстальніцкі інтэрфэйс.</translation>
+    </message>
+    <message>
+        <source>You don&apos;t have sufficient permissions to run this application. Administrative privileges are required to install Windscribe.</source>
+        <translation>У вас не дастаткова правоў для запуску гэтай праґрамы. Для ўсталёўкі Windscribe неабходныя правы адміністратара.</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>Install Settings</source>
+        <translation>Налады ўсталяваньня</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>Добра</translation>
+    </message>
+    <message>
+        <source>Factory Reset</source>
+        <translation>Ськінуць налады</translation>
+    </message>
+    <message>
+        <source>Create shortcut</source>
+        <translation>Стварыць цэтлік</translation>
+    </message>
+</context>
+</TS>

--- a/src/installer/windows/uninstaller/translations/windscribe_uninstaller_be.rc
+++ b/src/installer/windows/uninstaller/translations/windscribe_uninstaller_be.rc
@@ -1,0 +1,10 @@
+LANGUAGE LANG_BELARUSIAN, SUBLANG_NEUTRAL
+
+STRINGTABLE
+BEGIN
+    IDS_MSGBOX_TITLE "Выдаленьне Windscribe"
+    IDS_DIRECTORY_MISMATCH "Выдаленьне немагчыма працягнуць. Каталёґ усталёўкі не супадае з каталёґам выдаленьня."
+    IDS_CONFIRM_UNINSTALL "Вы ўпэўненыя, што хочаце цалкам выдаліць Windscribe і ўсе кампанэнты?"
+    IDS_UNINSTALL_SUCCESS "Windscribe быў пасьпяхова выдалены з вашага кампутара."
+    IDS_CLOSE_APP "Выйдзіце з праґрамы Windscribe, каб працягнуць выдаленьне. Зьвярніце ўвагу: пасьля выхаду з праґрамы вашае злучэньне не будзе абаронена."
+END

--- a/src/installer/windows/uninstaller/uninstall.rc
+++ b/src/installer/windows/uninstaller/uninstall.rc
@@ -49,6 +49,7 @@ END
 #pragma code_page(65001)
 
 #include "translations/windscribe_uninstaller_ar.rc"
+#include "translations/windscribe_uninstaller_be.rc"
 #include "translations/windscribe_uninstaller_cs.rc"
 #include "translations/windscribe_uninstaller_de.rc"
 #include "translations/windscribe_uninstaller_el.rc"

--- a/src/windscribe-cli/CMakeLists.txt
+++ b/src/windscribe-cli/CMakeLists.txt
@@ -108,6 +108,7 @@ add_executable(windscribe-cli ${SOURCES})
 
 set(TS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_cli_ar.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_cli_be.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_cli_cs.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_cli_de.ts
     ${CMAKE_CURRENT_SOURCE_DIR}/translations/windscribe_cli_el.ts

--- a/src/windscribe-cli/translations/windscribe_cli_be.ts
+++ b/src/windscribe-cli/translations/windscribe_cli_be.ts
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="be_BY">
+<context>
+    <name>BackendCommander</name>
+    <message>
+        <source>Data usage: %1 / %2</source>
+        <translation>Выкарыстаньне трафіку: %1 / %2</translation>
+    </message>
+    <message>
+        <source>Unlimited</source>
+        <translation>Безьліміт</translation>
+    </message>
+    <message>
+        <source>No locations.</source>
+        <translation>Няма месцазнаходжаньняў.</translation>
+    </message>
+    <message>
+        <source>Could not rotate IP.  Please check that you have Windscribe Pro or have this location in your plan, or try again later.</source>
+        <translation>Не ўдалося зьмяніць IP-адрас.  Праверце, ці маеце Windscribe Pro, альбо ці ўваходзіць гэтае месцазнаходжаньне ў вашы тарыфны плян, альбо паўтарыце спробу пазьней.</translation>
+    </message>
+    <message>
+        <source>Could not favourite IP.  Please check that you have Windscribe Pro or have this location in your plan, or try again later.</source>
+        <translation>Не ўдалося дадаць IP-адрас у абранае.  Праверце, ці маеце Windscribe Pro, альбо ці ўваходзіць гэтае месцазнаходжаньне ў вашы тарыфны плян, альбо паўтарыце спробу пазьней.</translation>
+    </message>
+    <message>
+        <source>Could not unfavourite IP.  Please check that the provided IP is valid.</source>
+        <translation>Не ўдалося прыбраць IP-адрас з абранага.  Праверце, ці правільны ўведзены IP-адрас.</translation>
+    </message>
+    <message>
+        <source>IP rotate already in progress.</source>
+        <translation>Зьмена IP-адраса ўжо ідзе.</translation>
+    </message>
+    <message>
+        <source>No AmneziaWG configurations available.</source>
+        <translation>Няма даступных канфіґурацый AmneziaWG.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Aborting: app did not start in time</source>
+        <translation>Перапыненьне: праґрама не запусцілася ў адведзены час</translation>
+    </message>
+    <message>
+        <source>Aborting: IPC communication error</source>
+        <translation>Перапыненьне: памылка межпрацэснай сувязі (IPC)</translation>
+    </message>
+    <message>
+        <source>Not logged in</source>
+        <translation>Уваход ва ўліковы запіс не выкананы</translation>
+    </message>
+    <message>
+        <source>Firewall already on</source>
+        <translation>Брандмаўэр ужо ўключаны</translation>
+    </message>
+    <message>
+        <source>Firewall already off</source>
+        <translation>Брандмаўэр ужо выключаны</translation>
+    </message>
+    <message>
+        <source>Firewall set to always on and can&apos;t be turned off</source>
+        <translation>Брандмаўэр заўсёды уключаны і не можа быць выключаны</translation>
+    </message>
+    <message>
+        <source>Already logged in</source>
+        <translation>Ужо ўвайшлі ва ўліковы запіс</translation>
+    </message>
+    <message>
+        <source>Already logged out</source>
+        <translation>Ужо выйшлі з уліковага запісу</translation>
+    </message>
+    <message>
+        <source>No update available</source>
+        <translation>Абнаўленьняў няма</translation>
+    </message>
+    <message>
+        <source>Internet connectivity: %1</source>
+        <translation>Падлучэньне да Інтэрнэту: %1</translation>
+    </message>
+    <message>
+        <source>Login state: %1</source>
+        <translation>Стан уваходу: %1</translation>
+    </message>
+    <message>
+        <source>Logged out</source>
+        <translation>Выйшлі</translation>
+    </message>
+    <message>
+        <source>Logging in</source>
+        <translation>Уваход ідзе</translation>
+    </message>
+    <message>
+        <source>Logged in</source>
+        <translation>Увайшлі</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation>Памылка: %1</translation>
+    </message>
+    <message>
+        <source>No internet connectivity</source>
+        <translation>Адсутнічае падлучэньне да Інтэрнэту</translation>
+    </message>
+    <message>
+        <source>No API connectivity</source>
+        <translation>Адсутнічае падлучэньне да API</translation>
+    </message>
+    <message>
+        <source>Incorrect username, password, or 2FA code</source>
+        <translation>Няправільныя імя карыстальніка, пароль альбо код 2FA</translation>
+    </message>
+    <message>
+        <source>SSL error</source>
+        <translation>Памылка SSL</translation>
+    </message>
+    <message>
+        <source>Session expired</source>
+        <translation>Сесія скончаная</translation>
+    </message>
+    <message>
+        <source>Rate limited</source>
+        <translation>Доступ абмежаваны</translation>
+    </message>
+    <message>
+        <source>Unknown error</source>
+        <translation>Невядомая памылка</translation>
+    </message>
+    <message>
+        <source>Connect state: %1</source>
+        <translation>Стан злучэньня: %1</translation>
+    </message>
+    <message>
+        <source>Connected: %1</source>
+        <translation>Падлучана: %1</translation>
+    </message>
+    <message>
+        <source>Connected</source>
+        <translation>Падлучана</translation>
+    </message>
+    <message>
+        <source>[Network interference]</source>
+        <translation>[Перашкоды ў сетцы]</translation>
+    </message>
+    <message>
+        <source>Connecting: %1</source>
+        <translation>Ідзе падлучэньне: %1</translation>
+    </message>
+    <message>
+        <source>Connecting</source>
+        <translation>Ідзе падлучэньне</translation>
+    </message>
+    <message>
+        <source>Disconnecting</source>
+        <translation>Ідзе адлучэньне</translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation>Адлучана</translation>
+    </message>
+    <message>
+        <source>Error: Location does not exist or is disabled</source>
+        <translation>Памылка: месцазнаходжаньне не існуе альбо адключана</translation>
+    </message>
+    <message>
+        <source>Error: You are out of data, or your account has been disabled. Upgrade to Pro to continue using Windscribe</source>
+        <translation>Памылка: у вас скончыўся трафік альбо ўліковы запіс заблякаваны. Перайдзіце на Pro, каб працягваць карыстацца Windscribe</translation>
+    </message>
+    <message>
+        <source>Error: Unable to start custom DNS service</source>
+        <translation>Памылка: не ўдалося запусьціць уласную службу DNS</translation>
+    </message>
+    <message>
+        <source>Error: WireGuard adapter setup failed</source>
+        <translation>Памылка: не ўдалося наладзіць адаптар WireGuard</translation>
+    </message>
+    <message>
+        <source>Error: Could not retrieve WireGuard configuration</source>
+        <translation>Памылка: не ўдалося атрымаць канфіґурацыю WireGuard</translation>
+    </message>
+    <message>
+        <source>Unknown state</source>
+        <translation>Невядомы стан</translation>
+    </message>
+    <message>
+        <source>Protocol: %1:%2</source>
+        <translation>Пратакол: %1:%2</translation>
+    </message>
+    <message>
+        <source>Firewall state: %1</source>
+        <translation>Стан брандмаўэра: %1</translation>
+    </message>
+    <message>
+        <source>Always On</source>
+        <translation>Заўсёды ўключаны</translation>
+    </message>
+    <message>
+        <source>On</source>
+        <translation>Уключаны</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Выключаны</translation>
+    </message>
+    <message>
+        <source>Update error: download failed. Please try again or try a different network.</source>
+        <translation>Памылка абнаўленьня: не ўдалося спампаваць. Паўтарыце спробу, альбо падлучыцеся да іншай сеткі.</translation>
+    </message>
+    <message>
+        <source>Update error: %1</source>
+        <translation>Памылка абнаўленьня: %1</translation>
+    </message>
+    <message>
+        <source>Update available: %1</source>
+        <translation>Даступнае абнаўленьне: %1</translation>
+    </message>
+    <message>
+        <source>available</source>
+        <translation>даступнае</translation>
+    </message>
+    <message>
+        <source>unavailable</source>
+        <translation>недаступнае</translation>
+    </message>
+    <message>
+        <source>Disconnected due to reaching WireGuard key limit.  Use &quot;windscribe-cli keylimit delete&quot; if you want to delete the oldest key instead, and try again.</source>
+        <translation>Адлучана: дасягнуты ліміт ключоў WireGuard.  Выкарыстоўвайце &quot;windscribe-cli keylimit delete&quot;, каб выдаліць найстарэйшы ключ, і паспрабуйце яшчэ раз.</translation>
+    </message>
+    <message>
+        <source>Downloading: %1%</source>
+        <translation>Ідзе спампоўваньне: %1%</translation>
+    </message>
+    <message>
+        <source>Username too short</source>
+        <translation>Імя карыстальніка занадта кароткае</translation>
+    </message>
+    <message>
+        <source>Password too short</source>
+        <translation>Пароль занадта кароткі</translation>
+    </message>
+    <message>
+        <source>Connection is in progress.  Use &apos;windscribe-cli status&apos; to check for connection status.</source>
+        <translation>Ідзе падлучэньне.  Выкарыстоўвайце &apos;windscribe-cli status&apos;, каб праверыць стан злучэньня.</translation>
+    </message>
+    <message>
+        <source>Disconnection is in progress.  Use &apos;windscribe-cli status&apos; to check for connection status.</source>
+        <translation>Ідзе адлучэньне.  Выкарыстоўвайце &apos;windscribe-cli status&apos;, каб праверыць стан злучэньня.</translation>
+    </message>
+    <message>
+        <source>Firewall is on.</source>
+        <translation>Брандмаўэр уключаны.</translation>
+    </message>
+    <message>
+        <source>Firewall is off.</source>
+        <translation>Брандмаўэр выключаны.</translation>
+    </message>
+    <message>
+        <source>Logs sent.</source>
+        <translation>Журналы адасланыя.</translation>
+    </message>
+    <message>
+        <source>Preferences reloaded.</source>
+        <translation>Налады перазагружаныя.</translation>
+    </message>
+    <message>
+        <source>Key limit behaviour is set.</source>
+        <translation>Паводзіны пры дасягненьні ліміту ключоў зададзеныя.</translation>
+    </message>
+    <message>
+        <source>Connection has been overridden by another command.</source>
+        <translation>Падлучэньне было перавызначана іншай камандай.</translation>
+    </message>
+    <message>
+        <source>Disconnection has been overridden by another command.</source>
+        <translation>Адлучэньне было перавызначана іншай камандай.</translation>
+    </message>
+    <message>
+        <source>Already disconnected</source>
+        <translation>Ужо адключана</translation>
+    </message>
+    <message>
+        <source>Logging out</source>
+        <translation>Выхад ідзе</translation>
+    </message>
+    <message>
+        <source>Need 2FA code</source>
+        <translation>Патрэбны код 2FA</translation>
+    </message>
+    <message>
+        <source>Incorrect 2FA code</source>
+        <translation>Некарэктны код 2FA</translation>
+    </message>
+    <message>
+        <source>(Device name: %1)</source>
+        <translation>(Імя прылады: %1)</translation>
+    </message>
+    <message>
+        <source>Internet connectivity is not available.  Try again later.</source>
+        <translation>Падлучэньне да Інтэрнэту недаступнае.  Паўтарыце спробу пазьней.</translation>
+    </message>
+    <message>
+        <source>Please type the numbers above to continue:</source>
+        <translation>Каб працягнуць, увядзіце лічбы вышэй:</translation>
+    </message>
+    <message>
+        <source> (10 Gbps)</source>
+        <translation> (10 Гбіт/с)</translation>
+    </message>
+    <message>
+        <source> (Disabled)</source>
+        <translation> (Адключанае)</translation>
+    </message>
+    <message>
+        <source> (Pro)</source>
+        <translation> (Pro)</translation>
+    </message>
+    <message>
+        <source>Not connected</source>
+        <translation>Не падлучана</translation>
+    </message>
+    <message>
+        <source>IP rotated.</source>
+        <translation>IP-адрас зьменены.</translation>
+    </message>
+    <message>
+        <source>IP favorited.</source>
+        <translation>IP-адрас дададзены ў абранае.</translation>
+    </message>
+    <message>
+        <source>IP unfavorited.</source>
+        <translation>IP-адрас прыбраны з абранага.</translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation>Некарэктны IP-адрас</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Add Belarusian (be-BY) localization across the app, CLI, installer, and uninstaller.

- Added translation files (.ts)
- Integrated them into CMake and Windows resources (windows uninstaller)
- Enabled Belarusian in the language switcher
- Capitalized "Беларуская" for UI consistency

Note: The translations are written using Belarusian Classical Orthography (Taraškievica), but currently use the `be-BY` locale code, which corresponds to the official reformed orthography.

Some platforms (e.g. Wikipedia) use a separate code like `be-tarask` to distinguish this variant:
https://be-tarask.wikipedia.org/

Would it be possible to add support for a separate locale (e.g. `be-tarask`) to distinguish this orthography variant?