### PR TITLE
macOS: skip VPN reconnect on same-SSID WiFi AP roams

### DIFF
--- a/src/client/engine/engine/networkdetectionmanager/networkdetectionmanager_mac.cpp
+++ b/src/client/engine/engine/networkdetectionmanager/networkdetectionmanager_mac.cpp
@@ -42,8 +42,11 @@ void NetworkDetectionManager_mac::onNetworkStateChanged()
 
     if (networkInterface != lastNetworkInterface_)
     {
+        bool significantChange = false;
+
         if (networkInterface.interfaceName != lastNetworkInterface_.interfaceName)
         {
+            significantChange = true;
             if (networkInterface.interfaceIndex == -1)
             {
                 qCInfo(LOG_BASIC) << "Primary Adapter down: " << lastNetworkInterface_.interfaceName;
@@ -62,6 +65,7 @@ void NetworkDetectionManager_mac::onNetworkStateChanged()
         }
         else if (networkInterface.networkOrSsid != lastNetworkInterface_.networkOrSsid)
         {
+            significantChange = true;
             qCInfo(LOG_BASIC) << "Primary Network Changed: "
                                << networkInterface.interfaceName
                                << " : " << networkInterface.networkOrSsid;
@@ -75,12 +79,14 @@ void NetworkDetectionManager_mac::onNetworkStateChanged()
         }
         else
         {
-            qCInfo(LOG_BASIC) << "Unidentified interface change";
-            // Can happen when changing interfaces
+            qCInfo(LOG_BASIC) << "Minor interface change on" << networkInterface.interfaceName
+                               << "(e.g. same-SSID AP roam), skipping reconnect";
         }
 
         lastNetworkInterface_ = networkInterface;
-        emit networkChanged(networkInterface);
+        if (significantChange) {
+            emit networkChanged(networkInterface);
+        }
     }
     else if (wifiAdapterUp != lastWifiAdapterUp_)
     {


### PR DESCRIPTION
## Summary

On macOS with enterprise WiFi (multiple APs, same SSID, FT_PSK), AP roams trigger a full VPN tunnel teardown and rebuild, causing 15-20s connectivity loss per event.

The root cause is that `onNetworkStateChanged()` in `networkdetectionmanager_mac.cpp` emits `networkChanged()` even when only cosmetic `NetworkInterface` fields change (e.g. metric, physicalAddress). The `operator!=` compares all 11 fields, so a same-SSID AP roam enters the "Unidentified interface change" branch and still triggers `ConnectionManager::updateConnectionSettings()`, which blindly disconnects and reconnects.

## Change

Gate `networkChanged()` emission on whether interfaceName or networkOrSsid actually changed. Minor interface property changes (same-SSID AP roams) still update the cached state but no longer trigger a reconnect. WireGuard and AmneziaWG handle endpoint roaming natively at the protocol level, so the tunnel stays up.

One file changed, 9 insertions, 3 deletions.

## Code path

1. `networkdetectionmanager_mac.cpp:onNetworkStateChanged()` — outer `!=` fires on any of 11 fields
2. `engine.cpp:onNetworkChange()` — calls `connectionManager_->updateConnectionSettings()`
3. `connectionmanager.cpp:updateConnectionSettings()` — if `STATE_CONNECTED`, calls `connector_->startDisconnect()`

## Testing

Verified the issue on macOS 26.4 (Tahoe), Windscribe 2.21.6, AmneziaWG, enterprise WPA2/FT_PSK WiFi with multiple APs. Observed 12 tunnel rebuilds in 47 minutes on the same SSID with retained DHCP lease (details in #307).

Fixes #307