### PR TITLE
security: filter 'plugin' directive in OpenVPN config to prevent LPE

### DIFF
--- a/src/client/client-common/utils/extraconfig.cpp
+++ b/src/client/client-common/utils/extraconfig.cpp
@@ -323,7 +323,7 @@ bool ExtraConfig::isLegalOpenVpnCommand(const QString &command) const
     const char *kUnsafeCommands[] = {
         "up", "down", "ipchange", "route-up", "route-pre-down", "auth-user-pass-verify",
         "client-connect", "client-disconnect", "learn-address", "tls-verify", "log", "log-append",
-        "tmp-dir"
+        "tmp-dir", "plugin"
     };
     const size_t kNumUnsafeCommands = sizeof(kUnsafeCommands) / sizeof(kUnsafeCommands[0]);
     for (size_t i = 0; i < kNumUnsafeCommands; ++i) {

--- a/src/helper/linux/ovpn.cpp
+++ b/src/helper/linux/ovpn.cpp
@@ -40,7 +40,8 @@ bool writeOVPNFile(const std::string &dnsScript, unsigned int port, const std::s
             line.rfind("auth-user-pass-verify", 2) != std::string::npos ||
             line.rfind("management", 2) != std::string::npos ||
             line.rfind("http-proxy", 2) != std::string::npos ||
-            line.rfind("socks-proxy", 2) != std::string::npos)
+            line.rfind("socks-proxy", 2) != std::string::npos ||
+            line.rfind("plugin", 2) != std::string::npos)
         {
             continue;
         }

--- a/src/helper/macos/ovpn.cpp
+++ b/src/helper/macos/ovpn.cpp
@@ -40,7 +40,8 @@ bool writeOVPNFile(const std::string &dnsScript, unsigned int port, const std::s
             line.rfind("auth-user-pass-verify", 2) != std::string::npos ||
             line.rfind("management", 2) != std::string::npos ||
             line.rfind("http-proxy", 2) != std::string::npos ||
-            line.rfind("socks-proxy", 2) != std::string::npos)
+            line.rfind("socks-proxy", 2) != std::string::npos ||
+            line.rfind("plugin", 2) != std::string::npos)
         {
             continue;
         }


### PR DESCRIPTION
## Summary
This PR fixes a critical local privilege escalation (LPE) vulnerability (Issue #313) where an unprivileged user can execute arbitrary code as root by injecting an OpenVPN `plugin` directive into the configuration.

## Changes
- **Helper (Linux/macOS):** Added `plugin` to the list of blocked directives in `writeOVPNFile()`. This prevents the privileged helper from writing a malicious plugin path to the final OpenVPN config.
- **Client:** Added `plugin` to `kUnsafeCommands` in `ExtraConfig::isLegalOpenVpnCommand()`. This prevents the client from accepting the directive from `windscribe_extra.conf`.

## Impact
Prevents local users from escalating to root via malicious shared objects loaded by OpenVPN.