### PR TITLE
fix(locales): correct machine-translated strings in Russian and Ukrainian

### DIFF
--- a/src/client/frontend/gui/translations/ws_desktop_ru.ts
+++ b/src/client/frontend/gui/translations/ws_desktop_ru.ts
@@ -39,7 +39,7 @@
     </message>
     <message>
         <source> transferred in </source>
-        <translation> переведено в </translation>
+        <translation> передано за </translation>
     </message>
     <message>
         <source>Connected for </source>
@@ -63,7 +63,7 @@
     </message>
     <message>
         <source>Favourite IP</source>
-        <translation>Любимый IP</translation>
+        <translation>Избранный IP</translation>
     </message>
     <message>
         <source>Rotate IP</source>
@@ -101,7 +101,7 @@
     </message>
     <message>
         <source>Favourites</source>
-        <translation>Любимые</translation>
+        <translation>Избранное</translation>
     </message>
 </context>
 <context>
@@ -289,14 +289,14 @@
     </message>
     <message>
         <source>Add</source>
-        <translation>Добавлять</translation>
+        <translation>Добавить</translation>
     </message>
 </context>
 <context>
     <name>GuiLocations::StaticIPDeviceInfo</name>
     <message>
         <source>Add</source>
-        <translation>Добавлять</translation>
+        <translation>Добавить</translation>
     </message>
 </context>
 <context>
@@ -444,7 +444,7 @@
     </message>
     <message>
         <source>Rate limited. Please wait before trying to login again.</source>
-        <translation>Ставка ограничена. Пожалуйста, подождите, прежде чем снова пытаться войти.</translation>
+        <translation>Превышен лимит запросов. Пожалуйста, подождите перед повторным входом.</translation>
     </message>
     <message>
         <source>Session is expired. Please login again</source>
@@ -519,7 +519,7 @@
     </message>
     <message>
         <source>Continue</source>
-        <translation>Продолжайте</translation>
+        <translation>Продолжить</translation>
     </message>
     <message>
         <source>Hash</source>
@@ -553,7 +553,7 @@ If you lose your account hash, it&apos;s gone forever and support cannot help yo
     </message>
     <message>
         <source>Invalid email</source>
-        <translation>Недействительное письмо</translation>
+        <translation>Неверный адрес эл. почты</translation>
     </message>
     <message>
         <source>Invalid hash</source>
@@ -899,7 +899,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>Rotating MAC Address</source>
-        <translation>Поворот MAC-адреса</translation>
+        <translation>Смена MAC-адреса</translation>
     </message>
     <message>
         <source>Wi-Fi is off</source>
@@ -1011,11 +1011,11 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>We could not set your favourite IP for this location.  Try again later.</source>
-        <translation>Мы не смогли установить ваш любимый IP-адрес для этого местоположения.  Повторите попытку позже.</translation>
+        <translation>Мы не смогли установить ваш избранный IP-адрес для этого местоположения. Повторите попытку позже.</translation>
     </message>
     <message>
         <source>Could not rotate IP</source>
-        <translation>Не удалось повернуть IP</translation>
+        <translation>Не удалось сменить IP</translation>
     </message>
     <message>
         <source>Try again later or go to our Status page for more info.</source>
@@ -1054,7 +1054,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     <name>MainWindowController</name>
     <message>
         <source>Quit Windscribe?</source>
-        <translation>Покинуть Windscribe?</translation>
+        <translation>Выйти из Windscribe?</translation>
     </message>
     <message>
         <source>Log Out of Windscribe?</source>
@@ -1189,7 +1189,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>UPGRADE &gt;</source>
-        <translation>МОДЕРНИЗАЦИЯ &gt;</translation>
+        <translation>УЛУЧШИТЬ &gt;</translation>
     </message>
 </context>
 <context>
@@ -1512,7 +1512,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>Clear Wi-Fi History</source>
-        <translation>Чистая история Wi-Fi</translation>
+        <translation>Очистить историю Wi-Fi</translation>
     </message>
     <message>
         <source>Are you sure?</source>
@@ -1901,7 +1901,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     <name>PreferencesWindow::NetworkOptionsNetworkWindowItem</name>
     <message>
         <source>Windscribe auto-connects if the device connects to this network.</source>
-        <translation>Windscribe автоматически подключится, если устройство соединиться с этой сетью.</translation>
+        <translation>Windscribe автоматически подключится, если устройство соединится с этой сетью.</translation>
     </message>
     <message>
         <source>Auto-Secure</source>
@@ -2026,7 +2026,7 @@ Connect to a network first</source>
     </message>
     <message>
         <source>Connection</source>
-        <translation>Связь</translation>
+        <translation>Подключение</translation>
     </message>
     <message>
         <source>R.O.B.E.R.T.</source>
@@ -2073,7 +2073,7 @@ Connect to a network first</source>
     </message>
     <message>
         <source>You have unsaved changes in edit fields. Do you want to save them?</source>
-        <translation>У вас есть несохраненные изменения в полях редактирования. Ты хочешь их спасти?</translation>
+        <translation>У вас есть несохранённые изменения в полях редактирования. Хотите их сохранить?</translation>
     </message>
     <message>
         <source>Save</source>
@@ -2608,7 +2608,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Disabled</source>
-        <translation>Отключение</translation>
+        <translation>Отключено</translation>
     </message>
     <message>
         <source>Config file too large</source>
@@ -2772,7 +2772,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Your application version is no longer supported. Please update to continue using %1.</source>
-        <translation>Ваша версия приложения больше не поддерживается. Пожалуйста, обновите информацию, чтобы продолжать использовать %1.</translation>
+        <translation>Ваша версия приложения больше не поддерживается. Пожалуйста, обновите приложение, чтобы продолжать пользоваться %1.</translation>
     </message>
     <message>
         <source>Please upgrade to a Pro account to continue using %1.</source>
@@ -2798,7 +2798,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     <name>ServerRatingsTooltip</name>
     <message>
         <source>Rate speed</source>
-        <translation>Скорость тарифа</translation>
+        <translation>Оценить скорость</translation>
     </message>
 </context>
 <context>
@@ -2848,11 +2848,11 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Quit Windscribe</source>
-        <translation>Брось Windscribe</translation>
+        <translation>Выйти из Windscribe</translation>
     </message>
     <message>
         <source>Favourites</source>
-        <translation>Любимые</translation>
+        <translation>Избранное</translation>
     </message>
     <message>
         <source>Show app</source>
@@ -2986,14 +2986,14 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Renew</source>
-        <translation>Обновлять</translation>
+        <translation>Продлить</translation>
     </message>
 </context>
 <context>
     <name>UpgradeWindow::UpgradeWindowItem</name>
     <message>
         <source>You&apos;re out of data!</source>
-        <translation>У вас закончилился пакет трафика!</translation>
+        <translation>У вас закончился пакет трафика!</translation>
     </message>
     <message>
         <source>Don&apos;t leave your front door open. Upgrade or wait until next month to get your monthly data allowance back.</source>

--- a/src/client/frontend/gui/translations/ws_desktop_uk.ts
+++ b/src/client/frontend/gui/translations/ws_desktop_uk.ts
@@ -39,15 +39,15 @@
     </message>
     <message>
         <source> transferred in </source>
-        <translation> переведено в </translation>
+        <translation> передано за </translation>
     </message>
     <message>
         <source>Connected for </source>
-        <translation>Підключено для </translation>
+        <translation>Підключено </translation>
     </message>
     <message>
         <source> transferred</source>
-        <translation> Передані</translation>
+        <translation> передано</translation>
     </message>
     <message>
         <source>Firewall</source>
@@ -67,7 +67,7 @@
     </message>
     <message>
         <source>Rotate IP</source>
-        <translation>Повернути IP</translation>
+        <translation>Змінити IP</translation>
     </message>
     <message>
         <source>FIREWALL</source>
@@ -192,7 +192,7 @@
     <name>FreeTrafficNotificationController</name>
     <message>
         <source>You reached %1% of your free bandwidth allowance</source>
-        <translation>Ви досягли 1% від ліміту вільної пропускної здатності;</translation>
+        <translation>Ви досягли %1% від ліміту безкоштовного трафіку.</translation>
     </message>
 </context>
 <context>
@@ -245,7 +245,7 @@
     </message>
     <message>
         <source>Choose</source>
-        <translation>Вибирати</translation>
+        <translation>Вибрати</translation>
     </message>
     <message>
         <source>The selected directory contains no custom configs</source>
@@ -345,7 +345,7 @@
     </message>
     <message>
         <source>Complete Puzzle to continue</source>
-        <translation>Здійсніть пазл, щоб продовжити</translation>
+        <translation>Завершіть пазл, щоб продовжити</translation>
     </message>
 </context>
 <context>
@@ -444,7 +444,7 @@
     </message>
     <message>
         <source>Rate limited. Please wait before trying to login again.</source>
-        <translation>Ставка обмежена. Будь ласка, зачекайте, перш ніж знову намагатися увійти.</translation>
+        <translation>Перевищено ліміт запитів. Будь ласка, зачекайте перед повторним входом.</translation>
     </message>
     <message>
         <source>Session is expired. Please login again</source>
@@ -519,7 +519,7 @@
     </message>
     <message>
         <source>Continue</source>
-        <translation>Продовжуй</translation>
+        <translation>Продовжити</translation>
     </message>
     <message>
         <source>Hash</source>
@@ -553,7 +553,7 @@ If you lose your account hash, it&apos;s gone forever and support cannot help yo
     </message>
     <message>
         <source>Invalid email</source>
-        <translation>Недійсний електронний лист</translation>
+        <translation>Неправильна адреса ел. пошти</translation>
     </message>
     <message>
         <source>Invalid hash</source>
@@ -615,7 +615,7 @@ If you lose your account hash, it&apos;s gone forever and support cannot help yo
     </message>
     <message>
         <source>Select Custom Config Folder</source>
-        <translation>Виберіть Custom Config Folder (Власна папка конфігурації)</translation>
+        <translation>Виберіть папку користувацьких конфігурацій</translation>
     </message>
     <message>
         <source>Security Risk</source>
@@ -689,7 +689,7 @@ If you lose your account hash, it&apos;s gone forever and support cannot help yo
         <source>Connection to Windscribe has been terminated.
 %1 transferred in %2</source>
         <translation>З&apos;єднання з Windscribe припинено.
-%1 переведено в %2</translation>
+%1 передано за %2</translation>
     </message>
     <message>
         <source>Could not start Proxy Gateway</source>
@@ -899,7 +899,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>Rotating MAC Address</source>
-        <translation>Поворот MAC-адреси</translation>
+        <translation>Зміна MAC-адреси</translation>
     </message>
     <message>
         <source>Wi-Fi is off</source>
@@ -1015,7 +1015,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>Could not rotate IP</source>
-        <translation>Не вдалося повернути IP</translation>
+        <translation>Не вдалося змінити IP</translation>
     </message>
     <message>
         <source>Try again later or go to our Status page for more info.</source>
@@ -1027,7 +1027,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>Back</source>
-        <translation>Задній</translation>
+        <translation>Назад</translation>
     </message>
     <message>
         <source>Manual connection mode failed</source>
@@ -1058,7 +1058,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>Log Out of Windscribe?</source>
-        <translation>Вийти з Windscribe?</translation>
+        <translation>Вийти з облікового запису Windscribe?</translation>
     </message>
     <message>
         <source>Quit</source>
@@ -1189,7 +1189,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>UPGRADE &gt;</source>
-        <translation>ОНОВЛЕННЯ &gt;</translation>
+        <translation>ПОКРАЩИТИ &gt;</translation>
     </message>
 </context>
 <context>
@@ -1306,11 +1306,11 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>Bundled</source>
-        <translation>Комплекті</translation>
+        <translation>Вбудований</translation>
     </message>
     <message>
         <source>None</source>
-        <translation>Ніхто</translation>
+        <translation>Нічого</translation>
     </message>
     <message>
         <source>Custom</source>
@@ -1512,7 +1512,7 @@ If the problem persists after a restart, please send a debug log and open a supp
     </message>
     <message>
         <source>Clear Wi-Fi History</source>
-        <translation>Чиста історія Wi-Fi</translation>
+        <translation>Очистити історію Wi-Fi</translation>
     </message>
     <message>
         <source>Are you sure?</source>
@@ -2069,15 +2069,15 @@ Connect to a network first</source>
     </message>
     <message>
         <source>Discard</source>
-        <translation>Викид</translation>
+        <translation>Скасувати</translation>
     </message>
     <message>
         <source>You have unsaved changes in edit fields. Do you want to save them?</source>
-        <translation>У вас є незбережені зміни в полях редагування. Хочеш їх врятувати?</translation>
+        <translation>У вас є незбережені зміни в полях редагування. Хочете їх зберегти?</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Збереження</translation>
+        <translation>Зберегти</translation>
     </message>
 </context>
 <context>
@@ -2215,14 +2215,14 @@ Connect to a network first</source>
     </message>
     <message>
         <source>Allowing</source>
-        <translation>Дозволяючи</translation>
+        <translation>Дозволено</translation>
     </message>
 </context>
 <context>
     <name>PreferencesWindow::RobertWindowItem</name>
     <message>
         <source>R.O.B.E.R.T.</source>
-        <translation>Р.О.Б.Е.Р.Т.</translation>
+        <translation>R.O.B.E.R.T.</translation>
     </message>
     <message>
         <source>R.O.B.E.R.T. is a customizable server-side domain and IP blocking tool. Select the block lists you wish to apply on all your devices by toggling the switch.</source>
@@ -2302,7 +2302,7 @@ Connect to a network first</source>
     </message>
     <message>
         <source>None</source>
-        <translation>Ніхто</translation>
+        <translation>Нічого</translation>
     </message>
     <message>
         <source>When Disconnected</source>
@@ -2310,7 +2310,7 @@ Connect to a network first</source>
     </message>
     <message>
         <source>Bundled</source>
-        <translation>Комплекті</translation>
+        <translation>Вбудований</translation>
     </message>
     <message>
         <source>Custom</source>
@@ -2516,7 +2516,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     <name>QObject</name>
     <message>
         <source>Custom</source>
-        <translation>Користувальницький</translation>
+        <translation>Користувацький</translation>
     </message>
     <message>
         <source>OS Default</source>
@@ -2580,7 +2580,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Internal</source>
-        <translation>Внутрішні</translation>
+        <translation>Внутрішній</translation>
     </message>
     <message>
         <source>Exclude</source>
@@ -2608,7 +2608,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Disabled</source>
-        <translation>Відключений</translation>
+        <translation>Вимкнено</translation>
     </message>
     <message>
         <source>Config file too large</source>
@@ -2628,7 +2628,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Missing &quot;Peer&quot; section</source>
-        <translation>Відсутній розділ &quot;Одноранговий&quot;</translation>
+        <translation>Відсутній розділ &quot;Peer&quot;</translation>
     </message>
     <message>
         <source>Missing &quot;PrivateKey&quot; in the &quot;Interface&quot; section</source>
@@ -2648,7 +2648,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Missing &quot;Endpoint&quot; in the &quot;Peer&quot; section</source>
-        <translation>Відсутня &quot;Кінцева точка&quot; в розділі &quot;Peer&quot;</translation>
+        <translation>Відсутній &quot;Endpoint&quot; в розділі &quot;Peer&quot;</translation>
     </message>
     <message>
         <source>Invalid &quot;PrivateKey&quot; format</source>
@@ -2684,7 +2684,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>AmneziaWG init parameter too large</source>
-        <translation>AmneziaWG init занадто великий параметр</translation>
+        <translation>Параметр ініціалізації AmneziaWG занадто великий</translation>
     </message>
     <message>
         <source>Static IPs</source>
@@ -2760,7 +2760,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Always On+</source>
-        <translation>Завжди на зв&apos;язку+</translation>
+        <translation>Завжди ввімкнено+</translation>
     </message>
     <message>
         <source>Custom configs</source>
@@ -2780,11 +2780,11 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Regular</source>
-        <translation>Регулярні</translation>
+        <translation>Звичайний</translation>
     </message>
     <message>
         <source>Alternate</source>
-        <translation>Альтернатива</translation>
+        <translation>Альтернативний</translation>
     </message>
 </context>
 <context>
@@ -2848,7 +2848,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Quit Windscribe</source>
-        <translation>Кинь Windscribe</translation>
+        <translation>Вийти з Windscribe</translation>
     </message>
     <message>
         <source>Favourites</source>
@@ -2897,7 +2897,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Update</source>
-        <translation>Оновлювати</translation>
+        <translation>Оновити</translation>
     </message>
 </context>
 <context>
@@ -2950,7 +2950,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>%1 left</source>
-        <translation>%1 ліворуч</translation>
+        <translation>Залишилось %1</translation>
     </message>
     <message>
         <source>0 days left</source>
@@ -2958,7 +2958,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>1 day left</source>
-        <translation>Залишилось 1 днів</translation>
+        <translation>Залишився 1 день</translation>
     </message>
     <message>
         <source>2 days left</source>
@@ -2986,7 +2986,7 @@ If the reinstall does not help, please contact Windscribe support for assistance
     </message>
     <message>
         <source>Renew</source>
-        <translation>Обновляти</translation>
+        <translation>Продовжити</translation>
     </message>
 </context>
 <context>

--- a/src/installer/gui/installer-gui-common/translations/windscribe_installer_uk.ts
+++ b/src/installer/gui/installer-gui-common/translations/windscribe_installer_uk.ts
@@ -78,7 +78,7 @@
     </message>
     <message>
         <source>Quit</source>
-        <translation>Кинути</translation>
+        <translation>Вийти</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -231,7 +231,7 @@
     <name>SettingsWindow</name>
     <message>
         <source>Install Settings</source>
-        <translation>Інсталяція налаштувань</translation>
+        <translation>Налаштування встановлення</translation>
     </message>
     <message>
         <source>OK</source>

--- a/src/windscribe-cli/translations/windscribe_cli_ru.ts
+++ b/src/windscribe-cli/translations/windscribe_cli_ru.ts
@@ -13,7 +13,7 @@
     </message>
     <message>
         <source>No locations.</source>
-        <translation>Никаких локаций.</translation>
+        <translation>Нет локаций.</translation>
     </message>
     <message>
         <source>No ports available for the specified protocol.</source>
@@ -21,7 +21,7 @@
     </message>
     <message>
         <source>Could not rotate IP.  Please check that you have Windscribe Pro or have this location in your plan, or try again later.</source>
-        <translation>Не удалось повернуть IP.  Убедитесь, что у вас есть Windscribe Pro или есть ли это местоположение в вашем тарифном плане, или повторите попытку позже.</translation>
+        <translation>Не удалось сменить IP. Убедитесь, что у вас есть Windscribe Pro или что это местоположение входит в ваш план, либо повторите попытку позже.</translation>
     </message>
     <message>
         <source>Could not favourite IP.  Please check that you have Windscribe Pro or have this location in your plan, or try again later.</source>
@@ -29,11 +29,11 @@
     </message>
     <message>
         <source>Could not unfavourite IP.  Please check that the provided IP is valid.</source>
-        <translation>Не мог остаться нелюбимым IP.  Пожалуйста, убедитесь, что предоставленный IP-адрес действителен.</translation>
+        <translation>Не удалось убрать IP из избранного. Убедитесь, что указанный IP-адрес верен.</translation>
     </message>
     <message>
         <source>IP rotate already in progress.</source>
-        <translation>Ротация IP уже началась.</translation>
+        <translation>Смена IP уже выполняется.</translation>
     </message>
     <message>
         <source>No AmneziaWG configurations available.</source>
@@ -96,7 +96,7 @@
     </message>
     <message>
         <source>Logged in</source>
-        <translation>Авторизовался</translation>
+        <translation>Выполнен вход</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -124,7 +124,7 @@
     </message>
     <message>
         <source>Rate limited</source>
-        <translation>Тариф ограничен</translation>
+        <translation>Превышен лимит запросов</translation>
     </message>
     <message>
         <source>Unknown error</source>
@@ -140,7 +140,7 @@
     </message>
     <message>
         <source>Connected</source>
-        <translation>Связанный</translation>
+        <translation>Подключено</translation>
     </message>
     <message>
         <source>[Network interference]</source>
@@ -152,7 +152,7 @@
     </message>
     <message>
         <source>Connecting</source>
-        <translation>Соединительный</translation>
+        <translation>Подключение</translation>
     </message>
     <message>
         <source>Disconnecting</source>
@@ -160,7 +160,7 @@
     </message>
     <message>
         <source>Disconnected</source>
-        <translation>Бессвязный</translation>
+        <translation>Отключено</translation>
     </message>
     <message>
         <source>Error: Location does not exist or is disabled</source>
@@ -204,15 +204,15 @@
     </message>
     <message>
         <source>Always On</source>
-        <translation>Всегда на связи</translation>
+        <translation>Всегда включён</translation>
     </message>
     <message>
         <source>On</source>
-        <translation>На</translation>
+        <translation>Вкл.</translation>
     </message>
     <message>
         <source>Off</source>
-        <translation>От</translation>
+        <translation>Выкл.</translation>
     </message>
     <message>
         <source>Update error: download failed. Please try again or try a different network.</source>
@@ -268,7 +268,7 @@
     </message>
     <message>
         <source>Logs sent.</source>
-        <translation>Бревна отправлены.</translation>
+        <translation>Журналы отправлены.</translation>
     </message>
     <message>
         <source>Preferences reloaded.</source>
@@ -276,7 +276,7 @@
     </message>
     <message>
         <source>Key limit behaviour is set.</source>
-        <translation>Задается поведение ограничения клавиш.</translation>
+        <translation>Поведение при достижении лимита ключей задано.</translation>
     </message>
     <message>
         <source>Connection has been overridden by another command.</source>
@@ -324,7 +324,7 @@
     </message>
     <message>
         <source> (Pro)</source>
-        <translation> (Плюс)</translation>
+        <translation> (Pro)</translation>
     </message>
     <message>
         <source>Not connected</source>
@@ -332,15 +332,15 @@
     </message>
     <message>
         <source>IP rotated.</source>
-        <translation>Ротация IP.</translation>
+        <translation>IP сменён.</translation>
     </message>
     <message>
         <source>IP favorited.</source>
-        <translation>IP в избранном.</translation>
+        <translation>IP добавлен в избранное.</translation>
     </message>
     <message>
         <source>IP unfavorited.</source>
-        <translation>IP не в избранном.</translation>
+        <translation>IP удалён из избранного.</translation>
     </message>
     <message>
         <source>Invalid IP address</source>

--- a/src/windscribe-cli/translations/windscribe_cli_uk.ts
+++ b/src/windscribe-cli/translations/windscribe_cli_uk.ts
@@ -21,19 +21,19 @@
     </message>
     <message>
         <source>Could not rotate IP.  Please check that you have Windscribe Pro or have this location in your plan, or try again later.</source>
-        <translation>Не вдалося повернути ІП.  Будь ласка, переконайтеся, що у вас є Windscribe Pro або є це місце у вашому плані, або спробуйте пізніше.</translation>
+        <translation>Не вдалося змінити IP. Переконайтеся, що у вас є Windscribe Pro або що це місце входить у ваш план, або спробуйте пізніше.</translation>
     </message>
     <message>
         <source>Could not favourite IP.  Please check that you have Windscribe Pro or have this location in your plan, or try again later.</source>
-        <translation>Не зміг вибратися IP.  Будь ласка, переконайтеся, що у вас є Windscribe Pro або є це місце у вашому плані, або спробуйте пізніше.</translation>
+        <translation>Не вдалося додати IP до вибраного. Переконайтеся, що у вас є Windscribe Pro або що це місце входить у ваш план, або спробуйте пізніше.</translation>
     </message>
     <message>
         <source>Could not unfavourite IP.  Please check that the provided IP is valid.</source>
-        <translation>Не міг не обійтися без улюбленого ІП.  Будь ласка, перевірте дійсність наданої IP-адреси.</translation>
+        <translation>Не вдалося видалити IP з вибраного. Переконайтеся, що вказана IP-адреса вірна.</translation>
     </message>
     <message>
         <source>IP rotate already in progress.</source>
-        <translation>ІП обертання вже в процесі.</translation>
+        <translation>Зміна IP вже виконується.</translation>
     </message>
     <message>
         <source>No AmneziaWG configurations available.</source>
@@ -124,7 +124,7 @@
     </message>
     <message>
         <source>Rate limited</source>
-        <translation>Ставка обмежена</translation>
+        <translation>Перевищено ліміт запитів</translation>
     </message>
     <message>
         <source>Unknown error</source>
@@ -136,11 +136,11 @@
     </message>
     <message>
         <source>Connected: %1</source>
-        <translation>пов&apos;язаний: %1</translation>
+        <translation>Підключено: %1</translation>
     </message>
     <message>
         <source>Connected</source>
-        <translation>Підключений</translation>
+        <translation>Підключено</translation>
     </message>
     <message>
         <source>[Network interference]</source>
@@ -208,7 +208,7 @@
     </message>
     <message>
         <source>On</source>
-        <translation>На</translation>
+        <translation>Увімк.</translation>
     </message>
     <message>
         <source>Off</source>
@@ -324,7 +324,7 @@
     </message>
     <message>
         <source> (Pro)</source>
-        <translation> (Про)</translation>
+        <translation> (Pro)</translation>
     </message>
     <message>
         <source>Not connected</source>
@@ -332,15 +332,15 @@
     </message>
     <message>
         <source>IP rotated.</source>
-        <translation>ІП повернувся.</translation>
+        <translation>IP змінено.</translation>
     </message>
     <message>
         <source>IP favorited.</source>
-        <translation>IP вибраний.</translation>
+        <translation>IP додано до вибраного.</translation>
     </message>
     <message>
         <source>IP unfavorited.</source>
-        <translation>ІП невибране.</translation>
+        <translation>IP видалено з вибраного.</translation>
     </message>
     <message>
         <source>Invalid IP address</source>


### PR DESCRIPTION
Fix Russian and Ukrainian translation errors

Fixes numerous incorrect, machine-translated, and grammatically wrong strings
in the Russian and Ukrainian localization files.

For example: "Quit Windscribe" was "Брось/Кинь" (throw/abandon); "Logs sent"
was "Бревна отправлены" (logs of wood); connection state labels used random
adjectives ("Бессвязный", "Соединительный"); "Invalid email" read as postal
letter; Ukrainian bandwidth notification had literal "1%" instead of the "%1%"
placeholder; "Back" was "Задній" (rear); "None" was "Ніхто" (nobody).