### PR TITLE
Arch Linux: do not force-enable network services in installers

### DIFF
--- a/src/installer/cli/linux/arch_package/windscribe-cli.install
+++ b/src/installer/cli/linux/arch_package/windscribe-cli.install
@@ -24,10 +24,6 @@ post_install() {
         # Ensure the windscribe service group and user exist
         getent group windscribe >/dev/null 2>&1 || groupadd windscribe
         id -u windscribe >/dev/null 2>&1 || useradd -r -g windscribe -s /bin/false windscribe
-        systemctl enable NetworkManager.service || true
-        systemctl start NetworkManager.service || true
-        systemctl enable systemd-resolved || true
-        systemctl start systemd-resolved || true
         systemctl enable windscribe-helper
         systemctl start windscribe-helper
         ln -sf /opt/windscribe/windscribe-cli /usr/bin/windscribe-cli

--- a/src/installer/gui/linux/arch_package/windscribe.install
+++ b/src/installer/gui/linux/arch_package/windscribe.install
@@ -23,10 +23,6 @@ post_install() {
         # Ensure the windscribe service group and user exist
         getent group windscribe >/dev/null 2>&1 || groupadd windscribe
         id -u windscribe >/dev/null 2>&1 || useradd -r -g windscribe -s /bin/false windscribe
-        systemctl enable NetworkManager.service || true
-        systemctl start NetworkManager.service || true
-        systemctl enable systemd-resolved || true
-        systemctl start systemd-resolved || true
         systemctl enable windscribe-helper
         systemctl start windscribe-helper
         ln -sf /opt/windscribe/windscribe-cli /usr/bin/windscribe-cli


### PR DESCRIPTION
Arch Linux is a modular operating system where users often configure their own networking stack.
Force-enabling `NetworkManager` and `systemd-resolved` during installation actively overrides the user's explicit choice of network manager and DNS resolver. This can conflict with the user's active configuration and break their internet connection upon installing or updating the app. 

This PR removes the `systemctl start` and `systemctl enable` commands for `systemd-resolved` and `NetworkManager.service` from the Arch Linux installation scripts.