### PR TITLE
Accept pasted URLs in split tunneling IP/hostname field

### DIFF
--- a/src/client/client-common/tests/networkingvalidation.test.cpp
+++ b/src/client/client-common/tests/networkingvalidation.test.cpp
@@ -193,6 +193,31 @@ void TestNetworkingValidation::testIsDomain()
     QVERIFY(NetworkingValidation::isDomainWithWildcard("*.google.com"));
 }
 
+void TestNetworkingValidation::testNormalizeIpCidrOrDomain()
+{
+    // Already-valid values are returned trimmed, unchanged in substance.
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("google.com"), QString("google.com"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("  1.2.3.4  "), QString("1.2.3.4"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("10.0.0.0/24"), QString("10.0.0.0/24"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("snapp.ir"), QString("snapp.ir"));
+
+    // Pasted URLs should reduce to the host so split-tunneling can accept them.
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("https://snapp.ir/"), QString("snapp.ir"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("http://snapp.ir"), QString("snapp.ir"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("https://www.google.com/search?q=test"), QString("www.google.com"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("https://example.com:443/path"), QString("example.com"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("https://1.2.3.4/"), QString("1.2.3.4"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("https://[2001:db8::1]/"), QString("2001:db8::1"));
+
+    // Bare host with a trailing slash or path (no scheme).
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("snapp.ir/"), QString("snapp.ir"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("snapp.ir/foo"), QString("snapp.ir"));
+
+    // Invalid input is returned trimmed but not rewritten into something else.
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("  not a host  "), QString("not a host"));
+    QCOMPARE(NetworkingValidation::normalizeIpCidrOrDomain("https://"), QString("https://"));
+}
+
 void TestNetworkingValidation::testIsIpv4AndIsIpv6()
 {
     // v4 literals

--- a/src/client/client-common/tests/networkingvalidation.test.h
+++ b/src/client/client-common/tests/networkingvalidation.test.h
@@ -16,6 +16,7 @@ private slots:
     void testIsIpAndIsDomain_smoke();
     void testIsIp();
     void testIsDomain();
+    void testNormalizeIpCidrOrDomain();
     void testIsIpv4AndIsIpv6();
     void testIsIpCidr();
     void testIsValidIpForCidr();

--- a/src/client/client-common/utils/networkingvalidation.cpp
+++ b/src/client/client-common/utils/networkingvalidation.cpp
@@ -4,6 +4,7 @@
 #include <QAbstractSocket>
 #include <QHostAddress>
 #include <QRegularExpression>
+#include <QUrl>
 
 namespace {
 
@@ -145,6 +146,36 @@ bool NetworkingValidation::isIpOrDomain(const QString &str)
 bool NetworkingValidation::isIpCidrOrDomain(const QString &str)
 {
     return (isIpCidr(str) || isDomain(str));
+}
+
+QString NetworkingValidation::normalizeIpCidrOrDomain(const QString &str)
+{
+    const QString trimmed = str.trimmed();
+    if (trimmed.isEmpty() || isIpCidrOrDomain(trimmed)) {
+        return trimmed;
+    }
+
+    // Accept pasted URLs like https://example.com/path by extracting the host.
+    const QUrl url(trimmed, QUrl::TolerantMode);
+    if (url.isValid() && !url.scheme().isEmpty() && !url.host().isEmpty()) {
+        const QString host = url.host();
+        if (isIpCidrOrDomain(host)) {
+            return host;
+        }
+    }
+
+    // Bare hostname with a trailing slash or path: "example.com/" or "example.com/foo"
+    if (!trimmed.contains(QLatin1String("://"))) {
+        const int slash = trimmed.indexOf(QLatin1Char('/'));
+        if (slash > 0) {
+            const QString beforeSlash = trimmed.left(slash);
+            if (isIpCidrOrDomain(beforeSlash)) {
+                return beforeSlash;
+            }
+        }
+    }
+
+    return trimmed;
 }
 
 // checking the correctness of the address for the ctrld utility

--- a/src/client/client-common/utils/networkingvalidation.h
+++ b/src/client/client-common/utils/networkingvalidation.h
@@ -15,6 +15,10 @@ public:
     static bool isDomainWithWildcard(const QString &str);
     static bool isIpOrDomain(const QString &str);
     static bool isIpCidrOrDomain(const QString &str);
+    // If `str` is already a valid IP/CIDR/domain, return it trimmed. If it looks like a URL
+    // (e.g. "https://example.com/path"), return the extracted host when that host is a valid
+    // IP or domain. Otherwise return the trimmed original string unchanged.
+    static QString normalizeIpCidrOrDomain(const QString &str);
     static bool isCtrldCorrectAddress(const QString &str);
 
     static bool isValidIpForCidr(const QString &str);

--- a/src/client/frontend/gui/preferenceswindow/splittunnelingwindow/splittunnelingaddressesgroup.cpp
+++ b/src/client/frontend/gui/preferenceswindow/splittunnelingwindow/splittunnelingaddressesgroup.cpp
@@ -120,6 +120,8 @@ void SplitTunnelingAddressesGroup::onDeleteClicked()
 
 SplitTunnelingAddressesGroup::ValidationCode SplitTunnelingAddressesGroup::validate(QString &address)
 {
+    address = NetworkingValidation::normalizeIpCidrOrDomain(address);
+
     if (!NetworkingValidation::isIpCidrOrDomain(address)) {
         return ValidationCode::ERROR_INVALID;
     }


### PR DESCRIPTION
## Summary
- Split tunneling currently rejects pasted URLs like `https://snapp.ir/` and only accepts bare hosts like `example.com`.
- Normalize URL-like input to the hostname/IP before validation, so values such as `https://example.com/`, `http://example.com/path`, and `example.com/` are accepted and stored as the host.
- Existing IP, CIDR, and domain validation is unchanged; invalid hosts still fail as before.

## Test plan
- [ ] Open Preferences → Split Tunneling → IPs & Hostnames
- [ ] Add `snapp.ir` and confirm it still works
- [ ] Add `https://example.com/` and confirm it is accepted and stored as `example.com`
- [ ] Add `https://www.google.com/search?q=test` and confirm it is stored as `www.google.com`
- [ ] Add `example.com/` and confirm it is stored as `example.com`
- [ ] Confirm duplicate detection treats URL and bare host as the same entry
- [ ] Confirm invalid values (e.g. `not a host`, `https://`) still show the validation error
- [ ] Run `TestNetworkingValidation` (new `testNormalizeIpCidrOrDomain` cases)

